### PR TITLE
or combinator

### DIFF
--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -4,9 +4,7 @@ use parcel::Parser;
 
 fn match_char<'a>(expected: char) -> impl parcel::Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
-        Some(next) if *next == expected => {
-            Ok(parcel::MatchStatus::Match((&input[1..], next.clone())))
-        }
+        Some(next) if *next == expected => Ok(parcel::MatchStatus::Match((&input[1..], *next))),
         _ => Ok(parcel::MatchStatus::NoMatch(input)),
     }
 }

--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -20,13 +20,21 @@ fn parse_map(c: &mut Criterion) {
 }
 
 fn parse_or(c: &mut Criterion) {
+    let mut group = c.benchmark_group("or combinator");
     let seed_vec = vec!['a', 'b', 'c'];
 
-    c.bench_function("parse char vector with or combinator", |b| {
+    group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('d').or(|| match_char('a')).parse(&seed_vec);
+            let _expr = parcel::or(match_char('c'), || match_char('a')).parse(&seed_vec);
         });
     });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('c').or(|| match_char('a')).parse(&seed_vec);
+        });
+    });
+    group.finish();
 }
 
 criterion_group!(benches, parse_map, parse_or);

--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -10,11 +10,20 @@ fn match_char<'a>(expected: char) -> impl parcel::Parser<'a, &'a [char], char> {
 }
 
 fn parse_map(c: &mut Criterion) {
+    let mut group = c.benchmark_group("map combinator");
     let seed_vec = vec!['a', 'b', 'c'];
 
-    c.bench_function("parse char vector with map combinator", |b| {
+    group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
             let _expr = parcel::map(match_char('a'), |result| result.to_string())
+                .parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('a')
+                .map(|result| result.to_string())
                 .parse(black_box(&seed_vec));
         });
     });

--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -14,12 +14,22 @@ fn match_char<'a>(expected: char) -> impl parcel::Parser<'a, &'a [char], char> {
 fn parse_map(c: &mut Criterion) {
     let seed_vec = vec!['a', 'b', 'c'];
 
-    c.bench_function("parse expressions", |b| {
+    c.bench_function("parse char vector with map combinator", |b| {
         b.iter(|| {
             let _expr = parcel::map(match_char('a'), |result| result.to_string()).parse(&seed_vec);
         });
     });
 }
 
-criterion_group!(benches, parse_map);
+fn parse_or(c: &mut Criterion) {
+    let seed_vec = vec!['a', 'b', 'c'];
+
+    c.bench_function("parse char vector with or combinator", |b| {
+        b.iter(|| {
+            let _expr = match_char('d').or(|| match_char('a')).parse(&seed_vec);
+        });
+    });
+}
+
+criterion_group!(benches, parse_map, parse_or);
 criterion_main!(benches);

--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -1,4 +1,4 @@
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 extern crate parcel;
 use parcel::Parser;
 
@@ -14,7 +14,8 @@ fn parse_map(c: &mut Criterion) {
 
     c.bench_function("parse char vector with map combinator", |b| {
         b.iter(|| {
-            let _expr = parcel::map(match_char('a'), |result| result.to_string()).parse(&seed_vec);
+            let _expr = parcel::map(match_char('a'), |result| result.to_string())
+                .parse(black_box(&seed_vec));
         });
     });
 }
@@ -25,13 +26,15 @@ fn parse_or(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::or(match_char('c'), || match_char('a')).parse(&seed_vec);
+            let _expr = parcel::or(match_char('c'), || match_char('a')).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('c').or(|| match_char('a')).parse(&seed_vec);
+            let _expr = match_char('c')
+                .or(|| match_char('a'))
+                .parse(black_box(&seed_vec));
         });
     });
     group.finish();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ where
     }
 }
 
+// Provides a boxed wrapper to any parser trait implementation.
 pub struct BoxedParser<'a, Input, Output> {
     parser: Box<dyn Parser<'a, Input, Output> + 'a>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,17 @@ pub trait Parser<'a, Input, Output> {
     {
         BoxedParser::new(or(self, thunk_to_parser))
     }
+
+    fn map<F, NewOutput>(self, map_fn: F) -> BoxedParser<'a, Input, NewOutput>
+    where
+        Self: Sized + 'a,
+        Input: 'a,
+        Output: 'a,
+        NewOutput: 'a,
+        F: Fn(Output) -> NewOutput + 'a,
+    {
+        BoxedParser::new(map(self, map_fn))
+    }
 }
 
 impl<'a, F, Input, Output> Parser<'a, Input, Output> for F

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,7 +66,7 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
     }
 }
 
-fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
+pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a + Borrow<A>,
     P1: Parser<'a, A, B>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,11 @@ pub enum MatchStatus<U, T> {
 /// and providing an Error string for any problems.
 pub type ParseResult<'a, Input, Output> = Result<MatchStatus<Input, Output>, String>;
 
+/// Parser is the primary trait serving as the basis for all child combinators.
+/// The most important function defined in this trait is parse, which defines
+/// the function that will be called for all child parsers. As a convenience,
+/// Boxed Implementations of Parser functions are included as trait defaults,
+/// allowing chained parser calls to be made for the sake of code cleanliness.
 pub trait Parser<'a, Input, Output> {
     fn parse(&self, input: Input) -> ParseResult<'a, Input, Output>;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,6 +71,9 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
     }
 }
 
+/// Provides a short-circuiting or combinator taking a parser (P1) as an
+/// argument and a second parser (P2), provided via a closure thunk to prevent
+/// infinitely recursing.
 pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a + Borrow<A>,

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -2,7 +2,7 @@ use crate::{map, MatchStatus, Parser};
 
 fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
-        Some(next) if *next == expected => Ok(MatchStatus::Match((&input[1..], next.clone()))),
+        Some(next) if *next == expected => Ok(MatchStatus::Match((&input[1..], *next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -26,3 +26,13 @@ fn validate_parser_can_map_a_result() {
         map(match_char('a'), |result| { result.to_string() }).parse(&seed_vec)
     );
 }
+
+#[test]
+fn validate_parser_can_match_with_or() {
+    let seed_vec = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&seed_vec[1..], 'a'))),
+        match_char('d').or(|| match_char('a')).parse(&seed_vec)
+    );
+}

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,4 +1,4 @@
-use crate::{map, MatchStatus, Parser};
+use crate::{MatchStatus, Parser};
 
 fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
@@ -23,7 +23,9 @@ fn validate_parser_can_map_a_result() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&seed_vec[1..], 'a'.to_string()))),
-        map(match_char('a'), |result| { result.to_string() }).parse(&seed_vec)
+        match_char('a')
+            .map(|result| { result.to_string() })
+            .parse(&seed_vec)
     );
 }
 


### PR DESCRIPTION
# Introduction
This PR adds an `or` combinator along with a boxed parser for wrapping combinator calls up as a chain.

In addition to setting up the boxed parser for `or`, this PR also updates map to provide a chained, boxed implementation.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
