### PR TITLE
Add to_boxed method.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,15 @@ pub trait Parser<'a, Input, Output> {
     {
         BoxedParser::new(map(self, map_fn))
     }
+
+    fn to_boxed(self) -> BoxedParser<'a, Input, Output>
+    where
+        Self: Sized + 'a,
+        Input: 'a,
+        Output: 'a,
+    {
+        BoxedParser::new(self)
+    }
 }
 
 impl<'a, F, Input, Output> Parser<'a, Input, Output> for F
@@ -70,6 +79,14 @@ where
 {
     fn parse(&self, input: Input) -> ParseResult<'a, Input, Output> {
         self(input)
+    }
+}
+
+pub struct UnboxedParser {}
+
+impl UnboxedParser {
+    fn new() -> Self {
+        UnboxedParser {}
     }
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -9,69 +9,79 @@ fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
 
 #[test]
 fn validate_parser_should_parse_char_match() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[1..], 'a'))),
-        match_char('a').parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        match_char('a').parse(&input)
     );
 }
 
 #[test]
 fn validate_parser_can_map_a_result() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[1..], 'a'.to_string()))),
+        Ok(MatchStatus::Match((&input[1..], 'a'.to_string()))),
         match_char('a')
             .map(|result| { result.to_string() })
-            .parse(&seed_vec)
+            .parse(&input)
     );
 }
 
 #[test]
 fn validate_parser_can_match_with_or() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[1..], 'a'))),
-        match_char('d').or(|| match_char('a')).parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        match_char('d').or(|| match_char('a')).parse(&input)
     );
 }
 
 #[test]
 fn validate_parser_can_match_with_and_then() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[2..], 'b'))),
-        match_char('a')
-            .and_then(|_| match_char('b'))
-            .parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[2..], 'b'))),
+        match_char('a').and_then(|_| match_char('b')).parse(&input)
     );
 }
 
 #[test]
 fn validate_parser_joins_values_on_match_with_join_combinator() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[2..], ('a', 'b')))),
-        join(match_char('a'), match_char('b')).parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[2..], ('a', 'b')))),
+        join(match_char('a'), match_char('b')).parse(&input)
     );
 }
 
 #[test]
 fn validate_applicatives_can_retrieve_each_independent_value() {
-    let seed_vec = vec!['a', 'b', 'c'];
+    let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[2..], 'a'))),
-        left(join(match_char('a'), match_char('b'))).parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[2..], 'a'))),
+        left(join(match_char('a'), match_char('b'))).parse(&input)
     );
 
     assert_eq!(
-        Ok(MatchStatus::Match((&seed_vec[2..], 'b'))),
-        right(join(match_char('a'), match_char('b'))).parse(&seed_vec)
+        Ok(MatchStatus::Match((&input[2..], 'b'))),
+        right(join(match_char('a'), match_char('b'))).parse(&input)
+    );
+}
+
+#[test]
+fn validate_to_boxed_can_be_applied_to_an_arbitrary_parser() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[2..], 'b'))),
+        right(join(match_char('a'), match_char('b')))
+            .to_boxed()
+            .parse(&input)
     );
 }


### PR DESCRIPTION
# Introduction
This PR begins separating the concept of `BoxedParser` from an unboxed parser. Previously, unboxed operations could take place without pushing the parser onto the heap by directly invoking the combinator methods as opposed to calling the chained methods. This difference can be seen in the benchmark tests.

```rust
fn parse_or(c: &mut Criterion) {
    let mut group = c.benchmark_group("or combinator");
    let seed_vec = vec!['a', 'b', 'c'];

    group.bench_function("combinator with char vec", |b| {
        b.iter(|| {
            let _expr = parcel::or(match_char('c'), || match_char('a')).parse(black_box(&seed_vec));
        });
    });

    group.bench_function("boxed combinator with char vec", |b| {
        b.iter(|| {
            let _expr = match_char('c')
                .or(|| match_char('a'))
                .parse(black_box(&seed_vec));
        });
    });
    group.finish();
}
```
While this works, the syntax of calling the unboxed methods doesn't read as clearly as the chained, boxed methods. Thus this PR attempts to create a type for unboxed parsers that allows chaining of methods. and provides a to_boxed method to convert to a `BoxedParser`.

# Linked Issues
resolves #16 
# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
