### PR TITLE
Add skip combinator.

### DIFF
--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -36,6 +36,23 @@ fn parse_map(c: &mut Criterion) {
     });
 }
 
+fn parse_skip(c: &mut Criterion) {
+    let mut group = c.benchmark_group("skip combinator");
+    let seed_vec = vec!['a', 'b', 'c'];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::skip(match_char('a')).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('a').skip().parse(black_box(&seed_vec));
+        });
+    });
+}
+
 fn parse_or(c: &mut Criterion) {
     let mut group = c.benchmark_group("or combinator");
     let seed_vec = vec!['a', 'b', 'c'];
@@ -163,6 +180,7 @@ fn parse_applicatives(c: &mut Criterion) {
 criterion_group!(
     benches,
     parse_map,
+    parse_skip,
     parse_or,
     parse_and_then,
     parse_predicate,

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -38,6 +38,16 @@ fn parser_can_map_a_result() {
 }
 
 #[test]
+fn parser_can_skip_a_result() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[1..])),
+        match_char('a').skip().parse(&input)
+    );
+}
+
+#[test]
 fn parser_can_match_with_or() {
     let input = vec!['a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -38,12 +38,22 @@ fn parser_can_map_a_result() {
 }
 
 #[test]
-fn parser_can_skip_a_result() {
+fn parser_should_skip_a_result() {
     let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[1..])),
         match_char('a').skip().parse(&input)
+    );
+}
+
+#[test]
+fn parser_should_not_skip_input_if_parser_does_not_match() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[0..])),
+        match_char('x').skip().parse(&input)
     );
 }
 


### PR DESCRIPTION
# Introduction
Add a combinator to allow clean skipping of matches in a way that will appear to not be a match.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
