### PR TITLE
Add one_of combinator.

### DIFF
--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -83,14 +83,6 @@ fn parse_one_of(c: &mut Criterion) {
                 .parse(black_box(&seed_vec));
         });
     });
-
-    group.bench_function("boxed combinator with char vec", |b| {
-        b.iter(|| {
-            let _expr = match_char('c')
-                .or(|| match_char('a'))
-                .parse(black_box(&seed_vec));
-        });
-    });
     group.finish();
 }
 

--- a/benches/text_parsing_bench.rs
+++ b/benches/text_parsing_bench.rs
@@ -73,6 +73,27 @@ fn parse_or(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_one_of(c: &mut Criterion) {
+    let mut group = c.benchmark_group("one_of combinator");
+    let seed_vec = vec!['a', 'b', 'c'];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::one_of(vec![match_char('c'), match_char('b'), match_char('a')])
+                .parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('c')
+                .or(|| match_char('a'))
+                .parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_and_then(c: &mut Criterion) {
     let mut group = c.benchmark_group("and_then combinator");
     let seed_vec = vec!['a', 'b', 'c'];
@@ -200,6 +221,7 @@ criterion_group!(
     parse_map,
     parse_skip,
     parse_or,
+    parse_one_of,
     parse_and_then,
     parse_predicate,
     parse_zero_or_more,

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -68,6 +68,16 @@ fn parser_can_match_with_or() {
 }
 
 #[test]
+fn parser_can_match_with_one_of() {
+    let input = vec!['a', 'b', 'c'];
+    let parsers = vec![match_char('b'), match_char('c'), match_char('a')];
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        crate::one_of(parsers).parse(&input)
+    );
+}
+
+#[test]
 fn parser_can_match_with_and_then() {
     let input = vec!['a', 'b', 'c'];
 


### PR DESCRIPTION
# Introduction
This PR adds a one_of combinator for more compact parsing of a chain of or combinators.

```rust
    let input = vec!['a', 'b', 'c'];
    let parsers = vec![match_char('b'), match_char('c'), match_char('a')];
    assert_eq!(
        Ok(MatchStatus::Match((&input[1..], 'a'))),
        crate::one_of(parsers).parse(&input)
    );
}
```

# Linked Issues
resolves #38 
# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
