### PR TITLE
Add take_n and take_until_n combinators

### DIFF
--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -22,8 +22,7 @@ fn parse_map(c: &mut Criterion) {
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
-            let _expr = parcel::map(match_byte(0x00), |result| result)
-                .parse(black_box(&seed_vec));
+            let _expr = parcel::map(match_byte(0x00), |result| result).parse(black_box(&seed_vec));
         });
     });
 
@@ -103,6 +102,24 @@ fn parse_and_then(c: &mut Criterion) {
             let _expr = match_byte(0x00)
                 .and_then(|_| match_byte(0x01))
                 .parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
+fn parse_take_until_n(c: &mut Criterion) {
+    let mut group = c.benchmark_group("take_until_n combinator");
+    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::take_until_n(match_byte(0x00), 4).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_byte(0x00).take_until_n(4).parse(black_box(&seed_vec));
         });
     });
     group.finish();
@@ -217,6 +234,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_take_until_n,
     parse_predicate,
     parse_zero_or_more,
     parse_one_or_more,

--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -252,6 +252,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_take_n,
     parse_take_until_n,
     parse_predicate,
     parse_zero_or_more,

--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -125,6 +125,24 @@ fn parse_take_until_n(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_take_n(c: &mut Criterion) {
+    let mut group = c.benchmark_group("take_n combinator");
+    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+
+    group.bench_function("combinator with byte vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::take_n(match_byte(0x00), 4).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with byte vec", |b| {
+        b.iter(|| {
+            let _expr = match_byte(0x00).take_n(4).parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
     let seed_vec = vec![0x00, 0x01, 0x02];

--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -111,13 +111,13 @@ fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
     let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
 
-    group.bench_function("combinator with char vec", |b| {
+    group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
             let _expr = parcel::take_until_n(match_byte(0x00), 4).parse(black_box(&seed_vec));
         });
     });
 
-    group.bench_function("boxed combinator with char vec", |b| {
+    group.bench_function("boxed combinator with byte vec", |b| {
         b.iter(|| {
             let _expr = match_byte(0x00).take_until_n(4).parse(black_box(&seed_vec));
         });

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -106,6 +106,24 @@ fn parse_and_then(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_take_until_n(c: &mut Criterion) {
+    let mut group = c.benchmark_group("take_until_n combinator");
+    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::take_until_n(match_char('a'), 4).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('a').take_until_n(4).parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
     let seed_vec = vec!['a', 'b', 'c'];
@@ -214,6 +232,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_take_until_n,
     parse_predicate,
     parse_zero_or_more,
     parse_one_or_more,

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -124,6 +124,24 @@ fn parse_take_until_n(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_take_n(c: &mut Criterion) {
+    let mut group = c.benchmark_group("take_n combinator");
+    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::take_n(match_char('a'), 4).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = match_char('a').take_n(4).parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
     let seed_vec = vec!['a', 'b', 'c'];
@@ -232,6 +250,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_take_n,
     parse_take_until_n,
     parse_predicate,
     parse_zero_or_more,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,15 @@ pub trait Parser<'a, Input, Output> {
         BoxedParser::new(and_then(self, thunk))
     }
 
+    fn take_until_n(self, n: usize) -> BoxedParser<'a, Input, Vec<Output>>
+    where
+        Self: Sized + 'a,
+        Input: Copy + 'a,
+        Output: 'a,
+    {
+        BoxedParser::new(take_until_n(self, n))
+    }
+
     fn predicate<F>(self, predicate_case: F) -> BoxedParser<'a, Input, Output>
     where
         Self: Sized + 'a,
@@ -230,6 +239,28 @@ where
             MatchStatus::NoMatch(last_input) => Ok(MatchStatus::NoMatch(last_input)),
         },
         Err(e) => Err(e),
+    }
+}
+
+pub fn take_until_n<'a, P, A, B>(parser: P, n: usize) -> impl Parser<'a, A, Vec<B>>
+where
+    A: Copy + 'a,
+    P: Parser<'a, A, B>,
+{
+    move |mut input| {
+        let mut res_cnt = 0;
+        let mut result_acc: Vec<B> = Vec::new();
+        while let Ok(MatchStatus::Match((next_input, result))) = parser.parse(input) {
+            if res_cnt < n {
+                input = next_input;
+                result_acc.push(result);
+                res_cnt += 1;
+            } else {
+                break;
+            }
+        }
+
+        Ok(MatchStatus::Match((input, result_acc)))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -242,6 +242,8 @@ where
     }
 }
 
+/// Much like the one_or_more parser, this attempts to consume until n matches
+/// have occured. A match is returned if 1 < result count <= n.
 pub fn take_until_n<'a, P, A, B>(parser: P, n: usize) -> impl Parser<'a, A, Vec<B>>
 where
     A: Copy + 'a,
@@ -260,7 +262,11 @@ where
             }
         }
 
-        Ok(MatchStatus::Match((input, result_acc)))
+        if res_cnt > 0 {
+            Ok(MatchStatus::Match((input, result_acc)))
+        } else {
+            Ok(MatchStatus::NoMatch(input))
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -280,9 +280,7 @@ where
 }
 
 /// take_n must match exactly n sequential matches of parser: P otherwise
-/// NoMatch is returned.
-///
-/// TODO: This is just a copy of take_until_n right now
+/// NoMatch is returned. On a match, a Vec of the results is returned.
 pub fn take_n<'a, P, A, B>(parser: P, n: usize) -> impl Parser<'a, A, Vec<B>>
 where
     A: Copy + 'a,

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,5 +1,7 @@
 use crate::prelude::v1::*;
-use crate::{join, left, one_or_more, optional, predicate, right, zero_or_more, MatchStatus};
+use crate::{
+    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
+};
 
 fn match_byte<'a>(expected: u8) -> impl Parser<'a, &'a [u8], u8> {
     move |input: &'a [u8]| match input.get(0) {
@@ -84,6 +86,62 @@ fn parser_can_match_with_and_then() {
         match_byte(0x00)
             .and_then(|_| match_byte(0x01))
             .parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_take_until_n() {
+    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[4..],
+            vec![0x00, 0x00, 0x00, 0x00]
+        ))),
+        take_until_n(match_byte(0x00), 4).parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_boxed_take_until_n() {
+    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((
+            &input[4..],
+            vec![0x00, 0x00, 0x00, 0x00]
+        ))),
+        match_byte(0x00).take_until_n(4).parse(&input)
+    );
+}
+
+#[test]
+fn take_until_n_will_match_only_up_to_specified_limit() {
+    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))),
+        match_byte(0x00).take_until_n(3).parse(&input)
+    );
+}
+
+#[test]
+fn take_until_n_will_return_as_many_matches_as_possible() {
+    let input = vec![0x00, 0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+        match_byte(0x00).take_until_n(3).parse(&input)
+    );
+}
+
+#[test]
+fn take_until_n_returns_a_no_match_on_no_match() {
+    let input = vec![0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[0..])),
+        match_byte(0x03).take_until_n(2).parse(&input)
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,6 +1,7 @@
 use crate::prelude::v1::*;
 use crate::{
-    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
+    join, left, one_or_more, optional, predicate, right, take_n, take_until_n, zero_or_more,
+    MatchStatus,
 };
 
 fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
@@ -136,6 +137,56 @@ fn take_until_n_returns_a_no_match_on_no_match() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         match_char('d').take_until_n(2).parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_take_n() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        take_n(match_char('a'), 4).parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_boxed_take_n() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        match_char('a').take_n(4).parse(&input)
+    );
+}
+
+#[test]
+fn take_n_will_match_only_up_to_specified_limit() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        match_char('a').take_n(3).parse(&input)
+    );
+}
+
+#[test]
+fn take_n_will_fail_if_unable_to_match_defined_result() {
+    let input = vec!['a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[0..])),
+        match_char('a').take_n(3).parse(&input)
+    );
+}
+
+#[test]
+fn take_n_returns_a_no_match_on_no_match() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[0..])),
+        match_char('d').take_n(2).parse(&input)
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,5 +1,7 @@
 use crate::prelude::v1::*;
-use crate::{join, left, one_or_more, optional, predicate, right, zero_or_more, MatchStatus};
+use crate::{
+    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
+};
 
 fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
@@ -84,6 +86,46 @@ fn parser_can_match_with_and_then() {
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], 'b'))),
         match_char('a').and_then(|_| match_char('b')).parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_take_until_n() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        take_until_n(match_char('a'), 4).parse(&input)
+    );
+}
+
+#[test]
+fn parser_can_match_with_boxed_take_until_n() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        match_char('a').take_until_n(4).parse(&input)
+    );
+}
+
+#[test]
+fn take_until_n_will_match_only_up_to_specified_limit() {
+    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        match_char('a').take_until_n(3).parse(&input)
+    );
+}
+
+#[test]
+fn take_until_n_will_return_as_many_matches_as_possible() {
+    let input = vec!['a', 'a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+        match_char('a').take_until_n(3).parse(&input)
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -171,7 +171,7 @@ fn take_n_will_match_only_up_to_specified_limit() {
 }
 
 #[test]
-fn take_n_will_fail_if_unable_to_match_defined_result() {
+fn take_n_will_not_match_if_unable_to_match_n_results() {
     let input = vec!['a', 'a', 'b', 'c'];
 
     assert_eq!(

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -130,6 +130,16 @@ fn take_until_n_will_return_as_many_matches_as_possible() {
 }
 
 #[test]
+fn take_until_n_returns_a_no_match_on_no_match() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::NoMatch(&input[0..])),
+        match_char('d').take_until_n(2).parse(&input)
+    );
+}
+
+#[test]
 fn parser_joins_values_on_match_with_join_combinator() {
     let input = vec!['a', 'b', 'c'];
 


### PR DESCRIPTION
# Introduction
This PR adds a `take_n` and `take_until_n` combinator for working with sized series of data.

take_until_n

```rust
let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];

assert_eq!(
    Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
    take_until_n(match_char('a'), 4).parse(&input)
);
```

take_n

```rust
let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];

assert_eq!(
    Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
    take_n(match_char('a'), 4).parse(&input)
);
```

# Linked Issues
resolves #20 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
