### PR TITLE
Bump tag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcel"
-version = "1.5.0"
+version = "1.6.0"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
# Introduction
This PR fixes the tag version in cargo.toml bumping 1.5.0 -> 1.6.0
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [ ] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
