### PR TITLE
Switch vscode devcontainer from rls to rust-analyzer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
 	// "postCreateCommand": "rustc --version"
 	// Add the IDs of extensions you want installed when the container is created in the array below.
 	"extensions": [
-		"rust-lang.rust",
+		"matklad.rust-analyzer",
 		"bungcip.better-toml",
 		"vadimcn.vscode-lldb",
 		"alanwalk.markdown-toc"


### PR DESCRIPTION
# Introduction
This PR updates the VSCode devcontainer to provide rust-analyzer instead of the official rls for the rust language server implementation.
# Linked Issues
resolves #53 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
