### PR TITLE
Add utility character Parsers

### DIFF
--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 extern crate parcel;
-use parcel::parsers::character::{any_char, match_char};
+use parcel::parsers::character::{any_character, expect_character};
 use parcel::Parser;
 
 fn parse_map(c: &mut Criterion) {
@@ -9,13 +9,14 @@ fn parse_map(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::map(match_char('a'), |result| result).parse(black_box(&seed_vec));
+            let _expr =
+                parcel::map(expect_character('a'), |result| result).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a')
+            let _expr = expect_character('a')
                 .map(|result| result)
                 .parse(black_box(&seed_vec));
         });
@@ -28,13 +29,13 @@ fn parse_skip(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::skip(match_char('a')).parse(black_box(&seed_vec));
+            let _expr = parcel::skip(expect_character('a')).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').skip().parse(black_box(&seed_vec));
+            let _expr = expect_character('a').skip().parse(black_box(&seed_vec));
         });
     });
 }
@@ -45,14 +46,15 @@ fn parse_or(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::or(match_char('c'), || match_char('a')).parse(black_box(&seed_vec));
+            let _expr = parcel::or(expect_character('c'), || expect_character('a'))
+                .parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('c')
-                .or(|| match_char('a'))
+            let _expr = expect_character('c')
+                .or(|| expect_character('a'))
                 .parse(black_box(&seed_vec));
         });
     });
@@ -65,8 +67,12 @@ fn parse_one_of(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::one_of(vec![match_char('c'), match_char('b'), match_char('a')])
-                .parse(black_box(&seed_vec));
+            let _expr = parcel::one_of(vec![
+                expect_character('c'),
+                expect_character('b'),
+                expect_character('a'),
+            ])
+            .parse(black_box(&seed_vec));
         });
     });
     group.finish();
@@ -78,15 +84,15 @@ fn parse_and_then(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr =
-                parcel::and_then(match_char('a'), |_| match_char('b')).parse(black_box(&seed_vec));
+            let _expr = parcel::and_then(expect_character('a'), |_| expect_character('b'))
+                .parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a')
-                .and_then(|_| match_char('b'))
+            let _expr = expect_character('a')
+                .and_then(|_| expect_character('b'))
                 .parse(black_box(&seed_vec));
         });
     });
@@ -99,13 +105,15 @@ fn parse_take_until_n(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::take_until_n(match_char('a'), 4).parse(black_box(&seed_vec));
+            let _expr = parcel::take_until_n(expect_character('a'), 4).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').take_until_n(4).parse(black_box(&seed_vec));
+            let _expr = expect_character('a')
+                .take_until_n(4)
+                .parse(black_box(&seed_vec));
         });
     });
     group.finish();
@@ -117,13 +125,13 @@ fn parse_take_n(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::take_n(match_char('a'), 4).parse(black_box(&seed_vec));
+            let _expr = parcel::take_n(expect_character('a'), 4).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').take_n(4).parse(black_box(&seed_vec));
+            let _expr = expect_character('a').take_n(4).parse(black_box(&seed_vec));
         });
     });
     group.finish();
@@ -135,13 +143,14 @@ fn parse_predicate(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::predicate(any_char(), |&c| c != 'b').parse(black_box(&seed_vec));
+            let _expr =
+                parcel::predicate(any_character(), |&c| c != 'b').parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = any_char()
+            let _expr = any_character()
                 .predicate(|&c| c != 'b')
                 .parse(black_box(&seed_vec));
         });
@@ -155,13 +164,15 @@ fn parse_zero_or_more(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::zero_or_more(match_char('a')).parse(black_box(&seed_vec));
+            let _expr = parcel::zero_or_more(expect_character('a')).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').zero_or_more().parse(black_box(&seed_vec));
+            let _expr = expect_character('a')
+                .zero_or_more()
+                .parse(black_box(&seed_vec));
         });
     });
     group.finish();
@@ -173,13 +184,15 @@ fn parse_one_or_more(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::one_or_more(match_char('a')).parse(black_box(&seed_vec));
+            let _expr = parcel::one_or_more(expect_character('a')).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').one_or_more().parse(black_box(&seed_vec));
+            let _expr = expect_character('a')
+                .one_or_more()
+                .parse(black_box(&seed_vec));
         });
     });
     group.finish()
@@ -191,13 +204,13 @@ fn parse_optional(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::optional(match_char('a')).parse(black_box(&seed_vec));
+            let _expr = parcel::optional(expect_character('a')).parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("boxed combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = match_char('a').optional().parse(black_box(&seed_vec));
+            let _expr = expect_character('a').optional().parse(black_box(&seed_vec));
         });
     });
     group.finish()
@@ -209,20 +222,21 @@ fn parse_applicatives(c: &mut Criterion) {
 
     group.bench_function("join combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::join(match_char('a'), match_char('b')).parse(black_box(&seed_vec));
+            let _expr = parcel::join(expect_character('a'), expect_character('b'))
+                .parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("left combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::left(parcel::join(match_char('a'), match_char('b')))
+            let _expr = parcel::left(parcel::join(expect_character('a'), expect_character('b')))
                 .parse(black_box(&seed_vec));
         });
     });
 
     group.bench_function("right combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::right(parcel::join(match_char('a'), match_char('b')))
+            let _expr = parcel::right(parcel::join(expect_character('a'), expect_character('b')))
                 .parse(black_box(&seed_vec));
         });
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -264,9 +264,9 @@ where
 ///
 /// ```
 /// use parcel::prelude::v1::*;
-/// use parcel::parsers::character::match_char;
+/// use parcel::parsers::character::expect_character;
 /// let input = vec!['a', 'b', 'c'];
-/// let parsers = vec![match_char('b'), match_char('c'), match_char('a')];
+/// let parsers = vec![expect_character('b'), expect_character('c'), expect_character('a')];
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
 ///   parcel::one_of(parsers).parse(&input)

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -1,15 +1,275 @@
 use crate::prelude::v1::*;
+use crate::{join, one_or_more, optional, right, take_n};
 
-pub fn match_char<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
+macro_rules! char_vec_to_u16_from_radix {
+    ($chars:expr, $radix:expr) => {
+        u16::from_le(u16::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
+    };
+}
+
+macro_rules! char_vec_to_u8_from_radix {
+    ($chars:expr, $radix:expr) => {
+        u8::from_le(u8::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
+    };
+}
+
+macro_rules! char_vec_to_i8_from_radix {
+    ($chars:expr, $radix:expr) => {
+        i8::from_le(i8::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
+    };
+}
+
+/// Matches a single provided character, returning match if the next character
+/// in the array matches the expected value. Otherwise, a `NoMatch` is
+/// returned.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::expect_character;
+/// let input = vec!['a', 'b', 'c'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   expect_character('a').parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::expect_character;
+/// let input = vec!['a', 'b', 'c'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   expect_character('b').parse(&input)
+/// );
+/// ```
+pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) if next == expected => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }
 
-pub fn any_char<'a>() -> impl Parser<'a, &'a [char], char> {
+pub fn any_character<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], String> {
+    move |input: &'a [char]| {
+        let preparse_input = input;
+        let expected_len = expected.len();
+        let next: String = input.iter().take(expected_len).collect();
+        if &next == expected {
+            Ok(MatchStatus::Match((&input[expected_len..], next)))
+        } else {
+            Ok(MatchStatus::NoMatch(preparse_input))
+        }
+    }
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum Sign {
+    Positive,
+    Negative,
+}
+
+impl PartialEq<char> for Sign {
+    fn eq(&self, other: &char) -> bool {
+        match self {
+            &Self::Positive if *other == '+' => true,
+            &Self::Negative if *other == '-' => true,
+            _ => false,
+        }
+    }
+}
+
+pub fn non_newline_whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
+    expect_character(' ').or(|| expect_character('\t'))
+}
+
+pub fn space<'a>() -> impl Parser<'a, &'a [char], char> {
+    expect_character(' ')
+}
+
+pub fn tab<'a>() -> impl Parser<'a, &'a [char], char> {
+    expect_character('\t')
+}
+
+pub fn whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn alphabetic<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if next.is_alphabetic() => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn eof<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(_) => Ok(MatchStatus::NoMatch(input)),
+        None => Ok(MatchStatus::Match((&input[0..], ' '))),
+    }
+}
+
+pub fn newline<'a>() -> impl Parser<'a, &'a [char], char> {
+    expect_character('\n')
+}
+
+pub fn character<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if !next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+pub fn unsigned16<'a>() -> impl Parser<'a, &'a [char], u16> {
+    hex_u16().or(|| binary_u16()).or(|| dec_u16())
+}
+
+pub fn unsigned8<'a>() -> impl Parser<'a, &'a [char], u8> {
+    hex_u8().or(|| binary_u8()).or(|| dec_u8())
+}
+
+pub fn signed8<'a>() -> impl Parser<'a, &'a [char], i8> {
+    hex_i8().or(|| binary_i8()).or(|| dec_i8())
+}
+
+fn sign<'a>() -> impl Parser<'a, &'a [char], Sign> {
+    expect_character('+')
+        .or(|| expect_character('-'))
+        .map(|c| match c {
+            '-' => Sign::Negative,
+            _ => Sign::Positive,
+        })
+}
+
+fn hex_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
+    right(join(expect_character('$'), hex_bytes(2))).map(|hex| char_vec_to_u16_from_radix!(hex, 16))
+}
+
+fn hex_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
+    right(join(expect_character('$'), hex_bytes(1))).map(|hex| char_vec_to_u8_from_radix!(hex, 16))
+}
+
+fn hex_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
+    right(join(expect_character('$'), hex_bytes(1))).map(|hex| char_vec_to_i8_from_radix!(hex, 16))
+}
+
+pub fn hex_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
+    take_n(hex_digit(), bytes * 2)
+}
+
+pub fn hex_digit<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if next.is_digit(16) => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+fn binary_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
+    right(join(expect_character('%'), binary_bytes(2)))
+        .map(|bin| char_vec_to_u16_from_radix!(bin, 2))
+}
+
+fn binary_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
+    right(join(expect_character('%'), binary_bytes(1)))
+        .map(|bin| char_vec_to_u8_from_radix!(bin, 2))
+}
+
+fn binary_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
+    right(join(expect_character('%'), binary_bytes(1)))
+        .map(|bin| char_vec_to_i8_from_radix!(bin, 2))
+}
+
+pub fn binary_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
+    take_n(binary(), bytes * 8)
+}
+
+pub fn binary<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if next.is_digit(2) => Ok(MatchStatus::Match((&input[1..], next))),
+        _ => Ok(MatchStatus::NoMatch(input)),
+    }
+}
+
+fn dec_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
+    move |input: &'a [char]| {
+        let preparsed_input = input;
+        let res = one_or_more(decimal())
+            .map(|digits| {
+                let vd: String = digits.into_iter().collect();
+                u16::from_str_radix(&vd, 10)
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
+            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
+            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn dec_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
+    move |input: &'a [char]| {
+        let preparsed_input = input;
+        let res = one_or_more(decimal())
+            .map(|digits| {
+                let vd: String = digits.into_iter().collect();
+                u8::from_str_radix(&vd, 10)
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
+            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
+            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+fn dec_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
+    move |input: &'a [char]| {
+        let preparsed_input = input;
+        let res = join(optional(sign()), one_or_more(decimal()))
+            .map(|(sign, digits)| {
+                let pos_or_neg = match sign {
+                    Some(Sign::Negative) => '-',
+                    _ => '+',
+                };
+
+                let vd: String = vec![pos_or_neg]
+                    .into_iter()
+                    .chain(digits.into_iter())
+                    .collect();
+                i8::from_str_radix(&vd, 10)
+            })
+            .parse(input);
+
+        match res {
+            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
+            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
+            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
+            Err(e) => Err(e),
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn decimal<'a>() -> impl Parser<'a, &'a [char], char> {
+    move |input: &'a [char]| match input.get(0) {
+        Some(&next) if next.is_digit(10) => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -51,6 +51,31 @@ pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a [char], char>
     }
 }
 
+/// Matches any single character regardless of value. Returning a `Match`
+/// result containing the next character in the stream if there is one
+/// available to consume.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::any_character;
+/// let input = vec!['a', 'b', 'c'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   any_character().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::any_character;
+/// let input = vec![];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   any_character().parse(&input[0..])
+/// );
+/// ```
 pub fn any_character<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) => Ok(MatchStatus::Match((&input[1..], next))),

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -1,24 +1,4 @@
 use crate::prelude::v1::*;
-use crate::{join, one_or_more, optional, right, take_n};
-
-macro_rules! char_vec_to_u16_from_radix {
-    ($chars:expr, $radix:expr) => {
-        u16::from_le(u16::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
-    };
-}
-
-macro_rules! char_vec_to_u8_from_radix {
-    ($chars:expr, $radix:expr) => {
-        u8::from_le(u8::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
-    };
-}
-
-macro_rules! char_vec_to_i8_from_radix {
-    ($chars:expr, $radix:expr) => {
-        i8::from_le(i8::from_str_radix(&$chars.into_iter().collect::<String>(), $radix).unwrap())
-    };
-}
-
 /// Matches a single provided character, returning match if the next character
 /// in the array matches the expected value. Otherwise, a `NoMatch` is
 /// returned.
@@ -119,24 +99,6 @@ pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], Str
         }
     }
 }
-
-/// Sign is used entirely internally for conversion between signed integers.
-#[derive(Clone, Copy, PartialEq)]
-enum Sign {
-    Positive,
-    Negative,
-}
-
-impl PartialEq<char> for Sign {
-    fn eq(&self, other: &char) -> bool {
-        match self {
-            &Self::Positive if *other == '+' => true,
-            &Self::Negative if *other == '-' => true,
-            _ => false,
-        }
-    }
-}
-
 /// Matches any single whitespace char, excluding newlines.
 ///
 /// # Examples
@@ -345,145 +307,67 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [char], char> {
     }
 }
 
-pub fn unsigned16<'a>() -> impl Parser<'a, &'a [char], u16> {
-    hex_u16().or(|| binary_u16()).or(|| dec_u16())
-}
-
-pub fn unsigned8<'a>() -> impl Parser<'a, &'a [char], u8> {
-    hex_u8().or(|| binary_u8()).or(|| dec_u8())
-}
-
-pub fn signed8<'a>() -> impl Parser<'a, &'a [char], i8> {
-    hex_i8().or(|| binary_i8()).or(|| dec_i8())
-}
-
-fn sign<'a>() -> impl Parser<'a, &'a [char], Sign> {
-    expect_character('+')
-        .or(|| expect_character('-'))
-        .map(|c| match c {
-            '-' => Sign::Negative,
-            _ => Sign::Positive,
-        })
-}
-
-fn hex_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
-    right(join(expect_character('$'), hex_bytes(2))).map(|hex| char_vec_to_u16_from_radix!(hex, 16))
-}
-
-fn hex_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
-    right(join(expect_character('$'), hex_bytes(1))).map(|hex| char_vec_to_u8_from_radix!(hex, 16))
-}
-
-fn hex_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
-    right(join(expect_character('$'), hex_bytes(1))).map(|hex| char_vec_to_i8_from_radix!(hex, 16))
-}
-
-pub fn hex_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
-    take_n(hex_digit(), bytes * 2)
-}
-
-pub fn hex_digit<'a>() -> impl Parser<'a, &'a [char], char> {
+/// Matches any single digit character, taking a radix for the base encoding.
+///
+/// - hex: 16
+/// - dec: 10
+/// - oct: 8
+/// - bin: 2
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::digit;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   digit(16).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::digit;
+/// let input = vec!['9'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], '9'))),
+///   digit(10).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::digit;
+/// let input = vec!['7'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], '7'))),
+///   digit(8).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::digit;
+/// let input = vec!['1'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], '1'))),
+///   digit(2).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::digit;
+/// let input = vec!['\n'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   digit(16).parse(&input)
+/// );
+/// ```
+pub fn digit<'a>(radix: u32) -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_digit(16) => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-fn binary_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
-    right(join(expect_character('%'), binary_bytes(2)))
-        .map(|bin| char_vec_to_u16_from_radix!(bin, 2))
-}
-
-fn binary_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
-    right(join(expect_character('%'), binary_bytes(1)))
-        .map(|bin| char_vec_to_u8_from_radix!(bin, 2))
-}
-
-fn binary_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
-    right(join(expect_character('%'), binary_bytes(1)))
-        .map(|bin| char_vec_to_i8_from_radix!(bin, 2))
-}
-
-pub fn binary_bytes<'a>(bytes: usize) -> impl Parser<'a, &'a [char], Vec<char>> {
-    take_n(binary(), bytes * 8)
-}
-
-pub fn binary<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_digit(2) => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
-fn dec_u16<'a>() -> impl Parser<'a, &'a [char], u16> {
-    move |input: &'a [char]| {
-        let preparsed_input = input;
-        let res = one_or_more(decimal())
-            .map(|digits| {
-                let vd: String = digits.into_iter().collect();
-                u16::from_str_radix(&vd, 10)
-            })
-            .parse(input);
-
-        match res {
-            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
-            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
-            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-fn dec_u8<'a>() -> impl Parser<'a, &'a [char], u8> {
-    move |input: &'a [char]| {
-        let preparsed_input = input;
-        let res = one_or_more(decimal())
-            .map(|digits| {
-                let vd: String = digits.into_iter().collect();
-                u8::from_str_radix(&vd, 10)
-            })
-            .parse(input);
-
-        match res {
-            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
-            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
-            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-fn dec_i8<'a>() -> impl Parser<'a, &'a [char], i8> {
-    move |input: &'a [char]| {
-        let preparsed_input = input;
-        let res = join(optional(sign()), one_or_more(decimal()))
-            .map(|(sign, digits)| {
-                let pos_or_neg = match sign {
-                    Some(Sign::Negative) => '-',
-                    _ => '+',
-                };
-
-                let vd: String = vec![pos_or_neg]
-                    .into_iter()
-                    .chain(digits.into_iter())
-                    .collect();
-                i8::from_str_radix(&vd, 10)
-            })
-            .parse(input);
-
-        match res {
-            Ok(MatchStatus::Match((rem, Ok(u)))) => Ok(MatchStatus::Match((rem, u))),
-            Ok(MatchStatus::Match((_, Err(_)))) => Ok(MatchStatus::NoMatch(preparsed_input)),
-            Ok(MatchStatus::NoMatch(rem)) => Ok(MatchStatus::NoMatch(rem)),
-            Err(e) => Err(e),
-        }
-    }
-}
-
-#[allow(dead_code)]
-pub fn decimal<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_digit(10) => Ok(MatchStatus::Match((&input[1..], next))),
+        Some(&next) if next.is_digit(radix) => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -83,6 +83,30 @@ pub fn any_character<'a>() -> impl Parser<'a, &'a [char], char> {
     }
 }
 
+/// Matches a single provided &str, returning match if the next characters in
+/// the array matches the expected str. Otherwise, a `NoMatch` is returned.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::expect_str;
+/// let input = vec!['a', 'b', 'c'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], "ab".to_string()))),
+///   expect_str("ab").parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::expect_str;
+/// let input = vec!['a', 'b', 'c'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   expect_str("b").parse(&input)
+/// );
+/// ```
 pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], String> {
     move |input: &'a [char]| {
         let preparse_input = input;
@@ -96,6 +120,7 @@ pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], Str
     }
 }
 
+/// Sign is used entirely internally for conversion between signed integers.
 #[derive(Clone, Copy, PartialEq)]
 enum Sign {
     Positive,
@@ -112,18 +137,115 @@ impl PartialEq<char> for Sign {
     }
 }
 
+/// Matches any single whitespace char, excluding newlines.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::non_newline_whitespace;
+/// let input = vec![' ', '\t', 'a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], '\t'))),
+///   non_newline_whitespace().and_then(|_| non_newline_whitespace()).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::non_newline_whitespace;
+/// let input = vec!['\n'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   non_newline_whitespace().parse(&input)
+/// );
+/// ```
 pub fn non_newline_whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
     expect_character(' ').or(|| expect_character('\t'))
 }
 
+/// Matches any single space char.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::space;
+/// let input = vec![' ', 'a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], ' '))),
+///   space().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::space;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   space().parse(&input)
+/// );
+/// ```
 pub fn space<'a>() -> impl Parser<'a, &'a [char], char> {
     expect_character(' ')
 }
 
+/// Matches any single tab char.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::tab;
+/// let input = vec!['\t', 'a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], '\t'))),
+///   tab().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::tab;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   tab().parse(&input)
+/// );
+/// ```
 pub fn tab<'a>() -> impl Parser<'a, &'a [char], char> {
     expect_character('\t')
 }
 
+/// Matches any single whitespace char including newlines that matches the
+/// whitespace definitions defined in the
+/// [Unicode Character Database](https://www.unicode.org/reports/tr44/).
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::whitespace;
+/// let input = vec![' ', '\n', '\t', 'a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[3..], '\t'))),
+///   whitespace()
+///     .and_then(|_| whitespace())
+///     .and_then(|_| whitespace())
+///     .parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::whitespace;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   whitespace().parse(&input)
+/// );
+/// ```
 pub fn whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(&next) if next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
@@ -131,13 +253,33 @@ pub fn whitespace<'a>() -> impl Parser<'a, &'a [char], char> {
     }
 }
 
-pub fn alphabetic<'a>() -> impl Parser<'a, &'a [char], char> {
-    move |input: &'a [char]| match input.get(0) {
-        Some(&next) if next.is_alphabetic() => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
-    }
-}
-
+/// Matches if the end of the input array/file has been reached. Returning a
+/// `Match` containing a ' ' character as a placeholder.
+///
+/// Special care should be taken when this is used with conjunction with other
+/// parsers that may yield a similar match case.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::eof;
+/// let input = vec![];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[0..], ' '))),
+///   eof().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::eof;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   eof().parse(&input)
+/// );
+/// ```
 pub fn eof<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
         Some(_) => Ok(MatchStatus::NoMatch(input)),
@@ -145,13 +287,60 @@ pub fn eof<'a>() -> impl Parser<'a, &'a [char], char> {
     }
 }
 
+/// Matches any single newline character
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::newline;
+/// let input = vec!['\n'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], '\n'))),
+///   newline().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::newline;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   newline().parse(&input)
+/// );
+/// ```
 pub fn newline<'a>() -> impl Parser<'a, &'a [char], char> {
     expect_character('\n')
 }
 
-pub fn character<'a>() -> impl Parser<'a, &'a [char], char> {
+/// Matches any single alphabetic char as described in the
+/// [Unicode Character Database](https://www.unicode.org/reports/tr44/).
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::alphabetic;
+/// let input = vec!['a'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   alphabetic().parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::character::alphabetic;
+/// let input = vec!['\n'];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   alphabetic().parse(&input)
+/// );
+/// ```
+pub fn alphabetic<'a>() -> impl Parser<'a, &'a [char], char> {
     move |input: &'a [char]| match input.get(0) {
-        Some(&next) if !next.is_whitespace() => Ok(MatchStatus::Match((&input[1..], next))),
+        Some(&next) if next.is_alphabetic() => Ok(MatchStatus::Match((&input[1..], next))),
         _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,4 +1,4 @@
-use crate::parsers::character::{any_char, match_char};
+use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
 use crate::{
     join, left, one_or_more, optional, predicate, right, take_n, take_until_n, zero_or_more,
@@ -11,7 +11,7 @@ fn parser_should_parse_char_match() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], 'a'))),
-        match_char('a').parse(&input)
+        expect_character('a').parse(&input[0..])
     );
 }
 
@@ -21,9 +21,9 @@ fn parser_can_map_a_result() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], 'a'.to_string()))),
-        match_char('a')
+        expect_character('a')
             .map(|result| { result.to_string() })
-            .parse(&input)
+            .parse(&input[0..])
     );
 }
 
@@ -33,7 +33,7 @@ fn parser_should_skip_a_result() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[1..])),
-        match_char('a').skip().parse(&input)
+        expect_character('a').skip().parse(&input[0..])
     );
 }
 
@@ -43,7 +43,7 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        match_char('x').skip().parse(&input)
+        expect_character('x').skip().parse(&input[0..])
     );
 }
 
@@ -53,17 +53,23 @@ fn parser_can_match_with_or() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], 'a'))),
-        match_char('d').or(|| match_char('a')).parse(&input)
+        expect_character('d')
+            .or(|| expect_character('a'))
+            .parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_can_match_with_one_of() {
     let input = vec!['a', 'b', 'c'];
-    let parsers = vec![match_char('b'), match_char('c'), match_char('a')];
+    let parsers = vec![
+        expect_character('b'),
+        expect_character('c'),
+        expect_character('a'),
+    ];
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], 'a'))),
-        crate::one_of(parsers).parse(&input)
+        crate::one_of(parsers).parse(&input[0..])
     );
 }
 
@@ -73,7 +79,9 @@ fn parser_can_match_with_and_then() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], 'b'))),
-        match_char('a').and_then(|_| match_char('b')).parse(&input)
+        expect_character('a')
+            .and_then(|_| expect_character('b'))
+            .parse(&input[0..])
     );
 }
 
@@ -83,7 +91,7 @@ fn parser_can_match_with_take_until_n() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        take_until_n(match_char('a'), 4).parse(&input)
+        take_until_n(expect_character('a'), 4).parse(&input[0..])
     );
 }
 
@@ -93,7 +101,7 @@ fn parser_can_match_with_boxed_take_until_n() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        match_char('a').take_until_n(4).parse(&input)
+        expect_character('a').take_until_n(4).parse(&input[0..])
     );
 }
 
@@ -103,7 +111,7 @@ fn take_until_n_will_match_only_up_to_specified_limit() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
-        match_char('a').take_until_n(3).parse(&input)
+        expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
@@ -113,7 +121,7 @@ fn take_until_n_will_return_as_many_matches_as_possible() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], vec!['a', 'a']))),
-        match_char('a').take_until_n(3).parse(&input)
+        expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
@@ -123,7 +131,7 @@ fn take_until_n_returns_a_no_match_on_no_match() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        match_char('d').take_until_n(2).parse(&input)
+        expect_character('d').take_until_n(2).parse(&input[0..])
     );
 }
 
@@ -133,7 +141,7 @@ fn parser_can_match_with_take_n() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        take_n(match_char('a'), 4).parse(&input)
+        take_n(expect_character('a'), 4).parse(&input[0..])
     );
 }
 
@@ -143,7 +151,7 @@ fn parser_can_match_with_boxed_take_n() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        match_char('a').take_n(4).parse(&input)
+        expect_character('a').take_n(4).parse(&input[0..])
     );
 }
 
@@ -153,7 +161,7 @@ fn take_n_will_match_only_up_to_specified_limit() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
-        match_char('a').take_n(3).parse(&input)
+        expect_character('a').take_n(3).parse(&input[0..])
     );
 }
 
@@ -163,7 +171,7 @@ fn take_n_will_not_match_if_unable_to_match_n_results() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        match_char('a').take_n(3).parse(&input)
+        expect_character('a').take_n(3).parse(&input[0..])
     );
 }
 
@@ -173,7 +181,7 @@ fn take_n_returns_a_no_match_on_no_match() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        match_char('d').take_n(2).parse(&input)
+        expect_character('d').take_n(2).parse(&input[0..])
     );
 }
 
@@ -183,7 +191,7 @@ fn parser_joins_values_on_match_with_join_combinator() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], ('a', 'b')))),
-        join(match_char('a'), match_char('b')).parse(&input)
+        join(expect_character('a'), expect_character('b')).parse(&input[0..])
     );
 }
 
@@ -193,12 +201,12 @@ fn applicatives_can_retrieve_each_independent_value() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], 'a'))),
-        left(join(match_char('a'), match_char('b'))).parse(&input)
+        left(join(expect_character('a'), expect_character('b'))).parse(&input[0..])
     );
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], 'b'))),
-        right(join(match_char('a'), match_char('b'))).parse(&input)
+        right(join(expect_character('a'), expect_character('b'))).parse(&input[0..])
     );
 }
 
@@ -208,7 +216,7 @@ fn predicate_should_match_if_case_fail() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], 'a'))),
-        predicate(any_char(), |&c| c != 'c').parse(&input)
+        predicate(any_character(), |&c| c != 'c').parse(&input[0..])
     );
 }
 
@@ -218,7 +226,7 @@ fn predicate_should_not_match_if_case_is_true() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        predicate(any_char(), |&c| c != 'a').parse(&input)
+        predicate(any_character(), |&c| c != 'a').parse(&input[0..])
     );
 }
 
@@ -228,7 +236,7 @@ fn predicate_should_match_until_case_fails() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[2..], vec!['a', 'b']))),
-        zero_or_more(predicate(any_char(), |&c| c != 'c')).parse(&input)
+        zero_or_more(predicate(any_character(), |&c| c != 'c')).parse(&input[0..])
     );
 }
 
@@ -238,7 +246,7 @@ fn one_or_more_returns_no_match_when_no_matches_exist() {
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
-        one_or_more(match_char('b')).parse(&input)
+        one_or_more(expect_character('b')).parse(&input[0..])
     );
 }
 
@@ -248,7 +256,7 @@ fn zero_or_more_returns_match_when_matches_exist() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], vec!['a']))),
-        zero_or_more(match_char('a')).parse(&input)
+        zero_or_more(expect_character('a')).parse(&input[0..])
     );
 }
 
@@ -258,7 +266,7 @@ fn zero_or_more_returns_match_when_no_matches_exist() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[0..], Vec::new()))),
-        zero_or_more(match_char('b')).parse(&input)
+        zero_or_more(expect_character('b')).parse(&input[0..])
     );
 }
 
@@ -268,7 +276,7 @@ fn optional_matches_on_zero() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[0..], None))),
-        optional(match_char('b')).parse(&input)
+        optional(expect_character('b')).parse(&input[0..])
     );
 }
 
@@ -278,6 +286,6 @@ fn optional_matches_on_one() {
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[1..], Some('a')))),
-        optional(match_char('a')).parse(&input)
+        optional(expect_character('a')).parse(&input[0..])
     );
 }


### PR DESCRIPTION
# Introduction
This PR begins the process of adding helper parsers. Including a set of default character parsers that covers most simple use case parsing that is done.

```rust
use parcel::prelude::v1::*;
use parcel::parsers::character::expect_character;
let input = vec!['a', 'b', 'c'];
assert_eq!(
  Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
  expect_character('a').parse(&input)
);
```

# Linked Issues
resolves #50 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
