### PR TITLE
Begin publishing to crates.io

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,15 @@
+name: publish to crates io
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  publish to crates.io:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Publish release to crates.io
+    - run: cargo publish --token ${{ secrets.CRATES_IO_TOKEN }}
+    

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,11 @@ name = "parcel"
 version = "1.6.0"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
-publish = false
+description = "A toy parser combinator library for rust."
+license-file = "LICENSE"
+readme = "README.md"
+repository = "https://github.com/ncatelli/parcel/"
+keywords = ["parser", "parser combinators"]
 
 [dev-dependencies]
 criterion = "0.3"


### PR DESCRIPTION
# Introduction
This PR begins the process required to start publishing to crates.io. Currently it looks like the parcel project's namespace is being held by an inactive project/user. This PR depends on being able to contact said user and transfer ownership.

# Linked Issues
resolves #70 
# Dependencies

# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
