### PR TITLE
Make BoxedParser::new public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -444,7 +444,7 @@ pub struct BoxedParser<'a, Input, Output> {
 }
 
 impl<'a, Input, Output> BoxedParser<'a, Input, Output> {
-    fn new<P>(parser: P) -> Self
+    pub fn new<P>(parser: P) -> Self
     where
         P: Parser<'a, Input, Output> + 'a,
     {

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,2 +1,4 @@
+pub use crate::BoxedParser;
 pub use crate::MatchStatus;
+pub use crate::ParseResult;
 pub use crate::Parser;


### PR DESCRIPTION
# Introduction
This PR makes the `BoxedParser::new` method public as well as adds both the `BoxedParser` and `ParseResult` structs to the prelude.

# Linked Issues
resolves #73 
resolves #74 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
