### PR TITLE
Add peek_next combinator

### DIFF
--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -98,6 +98,27 @@ fn parse_and_then(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_peek_next(c: &mut Criterion) {
+    let mut group = c.benchmark_group("peek_next combinator");
+    let seed_vec = vec![0x00, 0x01, 0x02];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr =
+                parcel::peek_next(expect_byte(0x00), expect_byte(0x01)).parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = expect_byte(0x00)
+                .peek_next(expect_byte(0x01))
+                .parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
     let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
@@ -245,6 +266,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_peek_next,
     parse_take_n,
     parse_take_until_n,
     parse_predicate,

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -99,6 +99,27 @@ fn parse_and_then(c: &mut Criterion) {
     group.finish();
 }
 
+fn parse_peek_next(c: &mut Criterion) {
+    let mut group = c.benchmark_group("peek_next combinator");
+    let seed_vec = vec!['a', 'b', 'c'];
+
+    group.bench_function("combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = parcel::peek_next(expect_character('a'), expect_character('b'))
+                .parse(black_box(&seed_vec));
+        });
+    });
+
+    group.bench_function("boxed combinator with char vec", |b| {
+        b.iter(|| {
+            let _expr = expect_character('a')
+                .peek_next(expect_character('b'))
+                .parse(black_box(&seed_vec));
+        });
+    });
+    group.finish();
+}
+
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
     let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
@@ -251,6 +272,7 @@ criterion_group!(
     parse_or,
     parse_one_of,
     parse_and_then,
+    parse_peek_next,
     parse_take_n,
     parse_take_until_n,
     parse_predicate,

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -78,6 +78,18 @@ fn parser_can_match_with_and_then() {
 }
 
 #[test]
+fn parser_can_match_with_peek_next() {
+    let input = vec![0x00, 0x01, 0x02];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[1..], 0x00))),
+        expect_byte(0x00)
+            .peek_next(expect_byte(0x01))
+            .parse(&input[0..])
+    );
+}
+
+#[test]
 fn parser_can_match_with_take_until_n() {
     let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -86,6 +86,18 @@ fn parser_can_match_with_and_then() {
 }
 
 #[test]
+fn parser_can_match_with_peek_next() {
+    let input = vec!['a', 'b', 'c'];
+
+    assert_eq!(
+        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        expect_character('a')
+            .peek_next(expect_character('b'))
+            .parse(&input[0..])
+    );
+}
+
+#[test]
 fn parser_can_match_with_take_until_n() {
     let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
 


### PR DESCRIPTION
# Introduction
This PR introduces a `peek_next` combinator for peeking at the next element in the input source for a match while not consuming said source on a match.

Below illustrates a match and no-match case for each.

```rust
let input = vec![0x00, 0x01, 0x02];

assert_eq!(
    Ok(MatchStatus::Match((&input[1..], 0x00))),
    expect_byte(0x00)
        .peek_next(expect_byte(0x01))
        .parse(&input[0..])
);

assert_eq!(
    Ok(MatchStatus::NoMatch(&input[0..])),
    expect_byte(0x00)
        .peek_next(expect_byte(0x02))
        .parse(&input[0..])
);
```


# Linked Issues
resolves #79 

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
