### PR TITLE
Remove duplicate unittests in favor of doctests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1397,6 +1397,26 @@ where
 ///   parcel::optional(expect_character('c')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], Some(0x00)))),
+///   parcel::optional(expect_byte(0x00)).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+///   parcel::optional(expect_byte(0x02)).parse(&input)
+/// );
+/// ```
 pub fn optional<'a, P, A, B>(parser: P) -> impl Parser<'a, A, Option<B>>
 where
     A: Copy + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1272,6 +1272,26 @@ where
 ///   parcel::zero_or_more(expect_character('c')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x00, 0x01];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   parcel::zero_or_more(expect_byte(0x00)).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+///   parcel::zero_or_more(expect_byte(0x02)).parse(&input)
+/// );
+/// ```
 pub fn zero_or_more<'a, P, A, B>(parser: P) -> impl Parser<'a, A, Vec<B>>
 where
     A: Copy + 'a,
@@ -1310,6 +1330,26 @@ where
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::one_or_more(expect_character('c')).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x00, 0x01];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   parcel::one_or_more(expect_byte(0x00)).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   parcel::one_or_more(expect_byte(0x02)).parse(&input)
 /// );
 /// ```
 pub fn one_or_more<'a, P, A, B>(parser: P) -> impl Parser<'a, A, Vec<B>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -813,10 +813,23 @@ where
 /// use parcel::parsers::character::expect_character;
 /// let input = vec!['a', 'b', 'c'];
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], "the value: a".to_string()))),
+///   Ok(parcel::MatchStatus::Match((&input[1..], "a".to_string()))),
 ///   parcel::map(
 ///       expect_character('a'),
-///       |res| format!("the value: {}", res)
+///       |res| format!("{}", res)
+///   ).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], "0".to_string()))),
+///   parcel::map(
+///       expect_byte(0x00),
+///       |res| format!("{}", res)
 ///   ).parse(&input)
 /// );
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,6 +265,26 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('a').take_until_n(2).parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x00, 0x00];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   expect_byte(0x00).take_until_n(2).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], vec![0x00]))),
+    ///   expect_byte(0x00).take_until_n(2).parse(&input)
+    /// );
+    /// ```
     fn take_until_n(self, n: usize) -> BoxedParser<'a, Input, Vec<Output>>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -722,6 +722,16 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
 ///   parcel::or(expect_character('b'), || expect_character('a')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   parcel::or(expect_byte(0x01), || expect_byte(0x00)).parse(&input)
+/// );
+/// ```
 pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a + Borrow<A>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1499,6 +1499,21 @@ where
 ///   ).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], 0x00))),
+///   parcel::left(
+///       parcel::join(
+///           expect_byte(0x00),
+///           expect_byte(0x01)
+///       )
+///   ).parse(&input)
+/// );
+/// ```
 pub fn left<'a, P, A, B, C>(parser: P) -> impl Parser<'a, A, B>
 where
     A: Copy + Borrow<A> + 'a,
@@ -1524,6 +1539,21 @@ where
 ///       parcel::join(
 ///           expect_character('a'),
 ///           expect_character('b')
+///       )
+///   ).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+///   parcel::right(
+///       parcel::join(
+///           expect_byte(0x00),
+///           expect_byte(0x01)
 ///       )
 ///   ).parse(&input)
 /// );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -595,6 +595,16 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('a').skip().parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
+    ///   expect_byte(0x00).skip().parse(&input)
+    /// );
+    /// ```
     fn skip(self) -> BoxedParser<'a, Input, Output>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -459,6 +459,26 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('c').zero_or_more().parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x00, 0x01];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   expect_byte(0x00).zero_or_more().parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+    ///   expect_byte(0x02).zero_or_more().parse(&input)
+    /// );
+    /// ```
     fn zero_or_more(self) -> BoxedParser<'a, Input, Vec<Output>>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -551,9 +551,21 @@ pub trait Parser<'a, Input, Output> {
     /// use parcel::parsers::character::expect_character;
     /// let input = vec!['a', 'b', 'c'];
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], "the value: a".to_string()))),
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], "a".to_string()))),
     ///   expect_character('a').map(
-    ///       |res| format!("the value: {}", res)
+    ///       |res| format!("{}", res)
+    ///   ).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], "0".to_string()))),
+    ///   expect_byte(0x00).map(
+    ///       |res| format!("{}", res)
     ///   ).parse(&input)
     /// );
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -862,6 +862,16 @@ where
 ///   parcel::skip(expect_character('a')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
+///   parcel::skip(expect_byte(0x00)).parse(&input)
+/// );
+/// ```
 pub fn skip<'a, P, A, B>(parser: P) -> impl Parser<'a, A, B>
 where
     A: 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -772,6 +772,17 @@ where
 ///   parcel::one_of(parsers).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// let parsers = vec![expect_byte(0x01), expect_byte(0x02), expect_byte(0x00)];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   parcel::one_of(parsers).parse(&input)
+/// );
+/// ```
 pub fn one_of<'a, P, A, B>(parsers: Vec<P>) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a + Borrow<A>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -636,7 +636,27 @@ pub trait Parser<'a, Input, Output> {
     /// let input = vec!['a', 'b', 'c'];
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
-    ///   parcel::optional(expect_character('c')).parse(&input)
+    ///   expect_character('c').optional().parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], Some(0x00)))),
+    ///   expect_byte(0x00).optional().parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+    ///   expect_byte(0x02).optional().parse(&input)
     /// );
     /// ```
     fn optional(self) -> BoxedParser<'a, Input, Option<Output>>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1447,6 +1447,16 @@ where
 ///   parcel::join(expect_character('a'), expect_character('b')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], (0x00, 0x01)))),
+///   parcel::join(expect_byte(0x00), expect_byte(0x01)).parse(&input)
+/// );
+/// ```
 pub fn join<'a, P1, P2, A, B, C>(parser1: P1, parser2: P2) -> impl Parser<'a, A, (B, C)>
 where
     A: Copy + Borrow<A> + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,26 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('a').take_n(2).parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x00, 0x00];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   expect_byte(0x00).take_n(2).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+    ///   expect_byte(0x00).take_n(2).parse(&input)
+    /// );
+    /// ```
     fn take_n(self, n: usize) -> BoxedParser<'a, Input, Vec<Output>>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,16 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('b').or(|| expect_character('a')).parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+    ///   expect_byte(0x01).or(|| expect_byte(0x00)).parse(&input)
+    /// );
+    /// ```
     fn or<P>(self, thunk: impl Fn() -> P + 'a) -> BoxedParser<'a, Input, Output>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -915,6 +915,33 @@ where
 ///       })).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+///   parcel::and_then(
+///       expect_byte(0x00),
+///       |_| expect_byte(0x01),
+///   ).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], "01".to_string()))),
+///   parcel::and_then(
+///       expect_byte(0x00),
+///       |first_match| expect_byte(0x01).map(move |second_match| {
+///          format!("{}{}", first_match, second_match)
+///       })).parse(&input)
+/// );
+/// ```
 pub fn and_then<'a, P1, F, P2, A, B, C>(parser: P1, f: F) -> impl Parser<'a, A, C>
 where
     A: 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1134,6 +1134,26 @@ where
 ///   parcel::take_n(expect_character('a'), 2).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x00, 0x00];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   parcel::take_n(expect_byte(0x00), 2).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   parcel::take_n(expect_byte(0x00), 2).parse(&input)
+/// );
+/// ```
 pub fn take_n<'a, P, A, B>(parser: P, n: usize) -> impl Parser<'a, A, Vec<B>>
 where
     A: Copy + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -989,6 +989,32 @@ where
 ///   ).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   parcel::peek_next(
+///       expect_byte(0x00),
+///       expect_byte(0x01),
+///   ).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   parcel::peek_next(
+///       expect_byte(0x00),
+///       expect_byte(0x02),
+///   ).parse(&input)
+/// );
+/// ```
 pub fn peek_next<'a, P1, P2, A, B, C>(first: P1, second: P2) -> impl Parser<'a, A, B>
 where
     A: Copy + Borrow<A> + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,26 @@ pub trait Parser<'a, Input, Output> {
     ///   expect_character('c').one_or_more().parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x00, 0x01];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   expect_byte(0x00).one_or_more().parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+    ///   expect_byte(0x02).one_or_more().parse(&input)
+    /// );
+    /// ```
     fn one_or_more(self) -> BoxedParser<'a, Input, Vec<Output>>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,28 @@ pub trait Parser<'a, Input, Output> {
     ///   ).parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::any_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+    ///   any_byte().predicate(|&b| b != 0x02).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::any_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x01]))),
+    ///   parcel::one_or_more(
+    ///       any_byte().predicate(|&b| b != 0x02)
+    ///   ).parse(&input)
+    /// );
+    /// ```
     fn predicate<F>(self, predicate_case: F) -> BoxedParser<'a, Input, Output>
     where
         Self: Sized + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1210,6 +1210,28 @@ where
 ///   ).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::any_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   parcel::predicate(any_byte(), |&b| b != 0x02).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::any_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x01]))),
+///   parcel::one_or_more(
+///       parcel::predicate(any_byte(), |&b| b != 0x02)
+///   ).parse(&input)
+/// );
+/// ```
 pub fn predicate<'a, P, A, B, F>(parser: P, pred_case: F) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,16 +156,6 @@ pub trait Parser<'a, Input, Output> {
     ///
     /// ```
     /// use parcel::prelude::v1::*;
-    /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
-    /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
-    ///   expect_byte(0x00).and_then(|_| expect_byte(0x01)).parse(&input)
-    /// );
-    /// ```
-    ///
-    /// ```
-    /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
     /// let input = vec!['a', 'b', 'c'];
     /// assert_eq!(
@@ -176,6 +166,30 @@ pub trait Parser<'a, Input, Output> {
     ///       })).parse(&input)
     /// );
     /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+    ///   expect_byte(0x00).and_then(|_| expect_byte(0x01)).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], "01".to_string()))),
+    ///   expect_byte(0x00).and_then(
+    ///       |first_match| expect_byte(0x01).map(move |second_match| {
+    ///          format!("{}{}", first_match, second_match)
+    ///       })).parse(&input)
+    /// );
+    /// ```
+
     fn and_then<F, NextParser, NewOutput>(self, thunk: F) -> BoxedParser<'a, Input, NewOutput>
     where
         Self: Sized + 'a,
@@ -208,6 +222,18 @@ pub trait Parser<'a, Input, Output> {
     ///
     /// ```
     /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::character::expect_character;
+    /// let input = vec!['a', 'b', 'c'];
+    /// assert_eq!(
+    ///     Ok(MatchStatus::NoMatch(&input[0..])),
+    ///     expect_character('a')
+    ///         .peek_next(expect_character('c'))
+    ///         .parse(&input[0..])
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
     /// let input = vec![0x00, 0x01, 0x02];
     /// assert_eq!(
@@ -220,12 +246,12 @@ pub trait Parser<'a, Input, Output> {
     ///
     /// ```
     /// use parcel::prelude::v1::*;
-    /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
     /// assert_eq!(
     ///     Ok(MatchStatus::NoMatch(&input[0..])),
-    ///     expect_character('a')
-    ///         .peek_next(expect_character('c'))
+    ///     expect_byte(0x00)
+    ///         .peek_next(expect_byte(0x02))
     ///         .parse(&input[0..])
     /// );
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,6 +156,16 @@ pub trait Parser<'a, Input, Output> {
     ///
     /// ```
     /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+    ///   expect_byte(0x00).and_then(|_| expect_byte(0x01)).parse(&input)
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
     /// let input = vec!['a', 'b', 'c'];
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,18 @@ pub trait Parser<'a, Input, Output> {
     ///
     /// ```
     /// use parcel::prelude::v1::*;
+    /// use parcel::parsers::byte::expect_byte;
+    /// let input = vec![0x00, 0x01, 0x02];
+    /// assert_eq!(
+    ///     Ok(MatchStatus::Match((&input[1..], 0x00))),
+    ///     expect_byte(0x00)
+    ///         .peek_next(expect_byte(0x01))
+    ///         .parse(&input[0..])
+    /// );
+    /// ```
+    ///
+    /// ```
+    /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
     /// let input = vec!['a', 'b', 'c'];
     /// assert_eq!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1062,6 +1062,26 @@ where
 ///   parcel::take_until_n(expect_character('a'), 2).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x00, 0x00];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   parcel::take_until_n(expect_byte(0x00), 2).parse(&input)
+/// );
+/// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::parsers::byte::expect_byte;
+/// let input = vec![0x00, 0x01, 0x02];
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match((&input[1..], vec![0x00]))),
+///   parcel::take_until_n(expect_byte(0x00), 2).parse(&input)
+/// );
+/// ```
 pub fn take_until_n<'a, P, A, B>(parser: P, n: usize) -> impl Parser<'a, A, Vec<B>>
 where
     A: Copy + 'a,

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -135,7 +135,7 @@ pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [char], Str
         let preparse_input = input;
         let expected_len = expected.len();
         let next: String = input.iter().take(expected_len).collect();
-        if &next == expected {
+        if next == expected {
             Ok(MatchStatus::Match((&input[expected_len..], next)))
         } else {
             Ok(MatchStatus::NoMatch(preparse_input))

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
-use crate::{join, left, predicate, right, take_until_n};
+use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
@@ -72,21 +72,6 @@ fn take_n_returns_a_no_match_on_no_match() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0x03).take_n(2).parse(&input)
-    );
-}
-
-#[test]
-fn applicatives_can_retrieve_each_independent_value() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 0x00))),
-        left(join(expect_byte(0x00), expect_byte(0x01))).parse(&input)
-    );
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 0x01))),
-        right(join(expect_byte(0x00), expect_byte(0x01))).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -46,16 +46,6 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 }
 
 #[test]
-fn parser_can_match_with_or() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
-        expect_byte(0x03).or(|| expect_byte(0x00)).parse(&input)
-    );
-}
-
-#[test]
 fn parser_can_match_with_one_of() {
     let input = vec![0x00, 0x01, 0x02];
     let parsers = vec![expect_byte(0x01), expect_byte(0x02), expect_byte(0x00)];

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -56,18 +56,6 @@ fn parser_can_match_with_one_of() {
 }
 
 #[test]
-fn parser_can_match_with_peek_next() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
-        expect_byte(0x00)
-            .peek_next(expect_byte(0x01))
-            .parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_can_match_with_take_until_n() {
     let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,8 +1,7 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
 use crate::{
-    join, left, one_or_more, optional, predicate, right, take_n, take_until_n, zero_or_more,
-    MatchStatus,
+    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
 };
 
 #[test]
@@ -95,52 +94,6 @@ fn take_until_n_returns_a_no_match_on_no_match() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0x03).take_until_n(2).parse(&input)
-    );
-}
-
-#[test]
-fn parser_can_match_with_take_n() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[4..],
-            vec![0x00, 0x00, 0x00, 0x00]
-        ))),
-        take_n(expect_byte(0x00), 4).parse(&input)
-    );
-}
-
-#[test]
-fn parser_can_match_with_boxed_take_n() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[4..],
-            vec![0x00, 0x00, 0x00, 0x00]
-        ))),
-        expect_byte(0x00).take_n(4).parse(&input)
-    );
-}
-
-#[test]
-fn take_n_will_match_only_up_to_specified_limit() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))),
-        expect_byte(0x00).take_n(3).parse(&input)
-    );
-}
-
-#[test]
-fn take_n_will_not_match_if_unable_to_match_n_results() {
-    let input = vec![0x00, 0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_byte(0x00).take_n(3).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -13,16 +13,6 @@ fn parser_should_parse_byte_match() {
 }
 
 #[test]
-fn parser_can_map_a_result() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
-        expect_byte(0x00).map(|result| result).parse(&input)
-    );
-}
-
-#[test]
 fn parser_should_skip_a_result() {
     let input = vec![0x00, 0x01, 0x02];
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,8 +1,6 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
-use crate::{
-    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
-};
+use crate::{join, left, one_or_more, optional, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
@@ -149,26 +147,6 @@ fn one_or_more_returns_no_match_when_no_matches_exist() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         one_or_more(expect_byte(0x01)).parse(&input)
-    );
-}
-
-#[test]
-fn zero_or_more_returns_match_when_matches_exist() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], vec![0x00]))),
-        zero_or_more(expect_byte(0x00)).parse(&input)
-    );
-}
-
-#[test]
-fn zero_or_more_returns_match_when_no_matches_exist() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[0..], Vec::new()))),
-        zero_or_more(expect_byte(0x01)).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -23,16 +23,6 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 }
 
 #[test]
-fn parser_can_match_with_one_of() {
-    let input = vec![0x00, 0x01, 0x02];
-    let parsers = vec![expect_byte(0x01), expect_byte(0x02), expect_byte(0x00)];
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
-        crate::one_of(parsers).parse(&input)
-    );
-}
-
-#[test]
 fn parser_can_match_with_take_until_n() {
     let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
 
@@ -82,16 +72,6 @@ fn take_n_returns_a_no_match_on_no_match() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0x03).take_n(2).parse(&input)
-    );
-}
-
-#[test]
-fn parser_joins_values_on_match_with_join_combinator() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], (0x00, 0x01)))),
-        join(expect_byte(0x00), expect_byte(0x01)).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -13,16 +13,6 @@ fn parser_should_parse_byte_match() {
 }
 
 #[test]
-fn parser_should_skip_a_result() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[1..])),
-        expect_byte(0x00).skip().parse(&input)
-    );
-}
-
-#[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
     let input = vec![0x00, 0x01, 0x02];
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -56,18 +56,6 @@ fn parser_can_match_with_one_of() {
 }
 
 #[test]
-fn parser_can_match_with_and_then() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 0x01))),
-        expect_byte(0x00)
-            .and_then(|_| expect_byte(0x01))
-            .parse(&input)
-    );
-}
-
-#[test]
 fn parser_can_match_with_peek_next() {
     let input = vec![0x00, 0x01, 0x02];
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -69,19 +69,6 @@ fn parser_can_match_with_take_until_n() {
 }
 
 #[test]
-fn parser_can_match_with_boxed_take_until_n() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[4..],
-            vec![0x00, 0x00, 0x00, 0x00]
-        ))),
-        expect_byte(0x00).take_until_n(4).parse(&input)
-    );
-}
-
-#[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
     let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
-use crate::{join, left, one_or_more, optional, predicate, right, take_until_n};
+use crate::{join, left, optional, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
@@ -137,16 +137,6 @@ fn predicate_should_not_match_if_case_is_true() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
-    );
-}
-
-#[test]
-fn one_or_more_returns_no_match_when_no_matches_exist() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        one_or_more(expect_byte(0x01)).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -133,32 +133,12 @@ fn applicatives_can_retrieve_each_independent_value() {
 }
 
 #[test]
-fn predicate_should_match_if_case_fail() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
-        predicate(any_byte(), |&b| b != 0x02).parse(&input)
-    );
-}
-
-#[test]
 fn predicate_should_not_match_if_case_is_true() {
     let input = vec![0x00, 0x01, 0x02];
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
-    );
-}
-
-#[test]
-fn predicate_should_match_until_case_fails() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec![0x00, 0x01]))),
-        zero_or_more(predicate(any_byte(), |&c| c != 0x02)).parse(&input)
     );
 }
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
-use crate::{join, left, optional, predicate, right, take_until_n};
+use crate::{join, left, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
@@ -117,25 +117,5 @@ fn predicate_should_not_match_if_case_is_true() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
-    );
-}
-
-#[test]
-fn optional_matches_on_zero() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[0..], None))),
-        optional(expect_byte(0x01)).parse(&input)
-    );
-}
-
-#[test]
-fn optional_matches_on_one() {
-    let input = vec![0x00, 0x01, 0x02];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], Some(0x00)))),
-        optional(expect_byte(0x00)).parse(&input)
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -48,18 +48,6 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 }
 
 #[test]
-fn parser_can_match_with_or() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
-        expect_character('d')
-            .or(|| expect_character('a'))
-            .parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_can_match_with_one_of() {
     let input = vec!['a', 'b', 'c'];
     let parsers = vec![

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
-use crate::{join, left, optional, predicate, right, take_until_n};
+use crate::{join, left, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
@@ -128,25 +128,5 @@ fn predicate_should_not_match_if_case_is_true() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
-    );
-}
-
-#[test]
-fn optional_matches_on_zero() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[0..], None))),
-        optional(expect_character('b')).parse(&input[0..])
-    );
-}
-
-#[test]
-fn optional_matches_on_one() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], Some('a')))),
-        optional(expect_character('a')).parse(&input[0..])
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,8 +1,6 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
-use crate::{
-    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
-};
+use crate::{join, left, one_or_more, optional, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
@@ -162,26 +160,6 @@ fn one_or_more_returns_no_match_when_no_matches_exist() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         one_or_more(expect_character('b')).parse(&input[0..])
-    );
-}
-
-#[test]
-fn zero_or_more_returns_match_when_matches_exist() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], vec!['a']))),
-        zero_or_more(expect_character('a')).parse(&input[0..])
-    );
-}
-
-#[test]
-fn zero_or_more_returns_match_when_no_matches_exist() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[0..], Vec::new()))),
-        zero_or_more(expect_character('b')).parse(&input[0..])
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -62,18 +62,6 @@ fn parser_can_match_with_one_of() {
 }
 
 #[test]
-fn parser_can_match_with_peek_next() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
-        expect_character('a')
-            .peek_next(expect_character('b'))
-            .parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_can_match_with_take_until_n() {
     let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -62,18 +62,6 @@ fn parser_can_match_with_one_of() {
 }
 
 #[test]
-fn parser_can_match_with_and_then() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 'b'))),
-        expect_character('a')
-            .and_then(|_| expect_character('b'))
-            .parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_can_match_with_peek_next() {
     let input = vec!['a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -13,16 +13,6 @@ fn parser_should_parse_char_match() {
 }
 
 #[test]
-fn parser_should_skip_a_result() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[1..])),
-        expect_character('a').skip().parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
     let input = vec!['a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
-use crate::{join, left, predicate, right, take_until_n};
+use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
@@ -93,21 +93,6 @@ fn take_n_returns_a_no_match_on_no_match() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         expect_character('d').take_n(2).parse(&input[0..])
-    );
-}
-
-#[test]
-fn applicatives_can_retrieve_each_independent_value() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 'a'))),
-        left(join(expect_character('a'), expect_character('b'))).parse(&input[0..])
-    );
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], 'b'))),
-        right(join(expect_character('a'), expect_character('b'))).parse(&input[0..])
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -13,18 +13,6 @@ fn parser_should_parse_char_match() {
 }
 
 #[test]
-fn parser_can_map_a_result() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'.to_string()))),
-        expect_character('a')
-            .map(|result| { result.to_string() })
-            .parse(&input[0..])
-    );
-}
-
-#[test]
 fn parser_should_skip_a_result() {
     let input = vec!['a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,8 +1,7 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
 use crate::{
-    join, left, one_or_more, optional, predicate, right, take_n, take_until_n, zero_or_more,
-    MatchStatus,
+    join, left, one_or_more, optional, predicate, right, take_until_n, zero_or_more, MatchStatus,
 };
 
 #[test]
@@ -102,41 +101,11 @@ fn take_until_n_returns_a_no_match_on_no_match() {
 }
 
 #[test]
-fn parser_can_match_with_take_n() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        take_n(expect_character('a'), 4).parse(&input[0..])
-    );
-}
-
-#[test]
-fn parser_can_match_with_boxed_take_n() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        expect_character('a').take_n(4).parse(&input[0..])
-    );
-}
-
-#[test]
 fn take_n_will_match_only_up_to_specified_limit() {
     let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
 
     assert_eq!(
         Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
-        expect_character('a').take_n(3).parse(&input[0..])
-    );
-}
-
-#[test]
-fn take_n_will_not_match_if_unable_to_match_n_results() {
-    let input = vec!['a', 'a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_character('a').take_n(3).parse(&input[0..])
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,6 +1,6 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
-use crate::{join, left, one_or_more, optional, predicate, right, take_until_n};
+use crate::{join, left, optional, predicate, right, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
@@ -150,16 +150,6 @@ fn predicate_should_not_match_if_case_is_true() {
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
-    );
-}
-
-#[test]
-fn one_or_more_returns_no_match_when_no_matches_exist() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        one_or_more(expect_character('b')).parse(&input[0..])
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -97,16 +97,6 @@ fn take_n_returns_a_no_match_on_no_match() {
 }
 
 #[test]
-fn parser_joins_values_on_match_with_join_combinator() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], ('a', 'b')))),
-        join(expect_character('a'), expect_character('b')).parse(&input[0..])
-    );
-}
-
-#[test]
 fn applicatives_can_retrieve_each_independent_value() {
     let input = vec!['a', 'b', 'c'];
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -146,32 +146,12 @@ fn applicatives_can_retrieve_each_independent_value() {
 }
 
 #[test]
-fn predicate_should_match_if_case_fail() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
-        predicate(any_character(), |&c| c != 'c').parse(&input[0..])
-    );
-}
-
-#[test]
 fn predicate_should_not_match_if_case_is_true() {
     let input = vec!['a', 'b', 'c'];
 
     assert_eq!(
         Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
-    );
-}
-
-#[test]
-fn predicate_should_match_until_case_fails() {
-    let input = vec!['a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec!['a', 'b']))),
-        zero_or_more(predicate(any_character(), |&c| c != 'c')).parse(&input[0..])
     );
 }
 

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -72,16 +72,6 @@ fn parser_can_match_with_take_until_n() {
 }
 
 #[test]
-fn parser_can_match_with_boxed_take_until_n() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
-
-    assert_eq!(
-        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
-        expect_character('a').take_until_n(4).parse(&input[0..])
-    );
-}
-
-#[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
     let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
 


### PR DESCRIPTION
# Introduction
This PR begins moving tests that demonstrate functionality and usage into doctests. In addition, this PR also removes duplicate unittests, preferring documentation as the source of truth.

# Linked Issues
resolves #81 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
