### PR TITLE
Begin adding spanned metadata to parses

### DIFF
--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -5,7 +5,7 @@ use parcel::Parser;
 
 fn parse_map(c: &mut Criterion) {
     let mut group = c.benchmark_group("map combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -24,7 +24,7 @@ fn parse_map(c: &mut Criterion) {
 
 fn parse_skip(c: &mut Criterion) {
     let mut group = c.benchmark_group("skip combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -41,7 +41,7 @@ fn parse_skip(c: &mut Criterion) {
 
 fn parse_or(c: &mut Criterion) {
     let mut group = c.benchmark_group("or combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -62,7 +62,7 @@ fn parse_or(c: &mut Criterion) {
 
 fn parse_one_of(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_of combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -79,7 +79,7 @@ fn parse_one_of(c: &mut Criterion) {
 
 fn parse_and_then(c: &mut Criterion) {
     let mut group = c.benchmark_group("and_then combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with u8 vec", |b| {
         b.iter(|| {
@@ -100,7 +100,7 @@ fn parse_and_then(c: &mut Criterion) {
 
 fn parse_peek_next(c: &mut Criterion) {
     let mut group = c.benchmark_group("peek_next combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -121,7 +121,10 @@ fn parse_peek_next(c: &mut Criterion) {
 
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
-    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -141,7 +144,10 @@ fn parse_take_until_n(c: &mut Criterion) {
 
 fn parse_take_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_n combinator");
-    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -159,7 +165,7 @@ fn parse_take_n(c: &mut Criterion) {
 
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -179,7 +185,7 @@ fn parse_predicate(c: &mut Criterion) {
 
 fn parse_zero_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("zero_or_more combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -197,7 +203,7 @@ fn parse_zero_or_more(c: &mut Criterion) {
 
 fn parse_one_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_or_more combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -215,7 +221,7 @@ fn parse_one_or_more(c: &mut Criterion) {
 
 fn parse_optional(c: &mut Criterion) {
     let mut group = c.benchmark_group("optional combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -233,7 +239,7 @@ fn parse_optional(c: &mut Criterion) {
 
 fn parse_applicatives(c: &mut Criterion) {
     let mut group = c.benchmark_group("applicatives combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("join combinator with byte vec", |b| {
         b.iter(|| {

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -5,7 +5,7 @@ use parcel::Parser;
 
 fn parse_map(c: &mut Criterion) {
     let mut group = c.benchmark_group("map combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -25,7 +25,7 @@ fn parse_map(c: &mut Criterion) {
 
 fn parse_skip(c: &mut Criterion) {
     let mut group = c.benchmark_group("skip combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -42,7 +42,7 @@ fn parse_skip(c: &mut Criterion) {
 
 fn parse_or(c: &mut Criterion) {
     let mut group = c.benchmark_group("or combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -63,7 +63,7 @@ fn parse_or(c: &mut Criterion) {
 
 fn parse_one_of(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_of combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -80,7 +80,7 @@ fn parse_one_of(c: &mut Criterion) {
 
 fn parse_and_then(c: &mut Criterion) {
     let mut group = c.benchmark_group("and_then combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -101,7 +101,7 @@ fn parse_and_then(c: &mut Criterion) {
 
 fn parse_peek_next(c: &mut Criterion) {
     let mut group = c.benchmark_group("peek_next combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -122,7 +122,10 @@ fn parse_peek_next(c: &mut Criterion) {
 
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
-    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -142,7 +145,10 @@ fn parse_take_until_n(c: &mut Criterion) {
 
 fn parse_take_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_n combinator");
-    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -160,7 +166,7 @@ fn parse_take_n(c: &mut Criterion) {
 
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -181,7 +187,7 @@ fn parse_predicate(c: &mut Criterion) {
 
 fn parse_zero_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("zero_or_more combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -201,7 +207,7 @@ fn parse_zero_or_more(c: &mut Criterion) {
 
 fn parse_one_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_or_more combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -221,7 +227,7 @@ fn parse_one_or_more(c: &mut Criterion) {
 
 fn parse_optional(c: &mut Criterion) {
     let mut group = c.benchmark_group("optional combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -239,7 +245,7 @@ fn parse_optional(c: &mut Criterion) {
 
 fn parse_applicatives(c: &mut Criterion) {
     let mut group = c.benchmark_group("applicatives combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("join combinator with char vec", |b| {
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -993,7 +993,7 @@ where
 {
     move |input| match parser.parse(input) {
         Ok(sms) => match (sms.as_span(), sms.unwrap()) {
-            (span, MatchStatus::Match((next_input, result))) => f(result).parse(next_input),
+            (_, MatchStatus::Match((next_input, result))) => f(result).parse(next_input),
 
             (span, MatchStatus::NoMatch(last_input)) => Ok(SpannedMatchStatus::new(
                 span,
@@ -1072,7 +1072,7 @@ where
             (span, MatchStatus::Match((next_input, result))) => {
                 let first_input = next_input;
                 if let Ok(SpannedMatchStatus {
-                    span: span,
+                    span: _,
                     match_status: MatchStatus::Match(_),
                 }) = second.parse(next_input)
                 {
@@ -1165,7 +1165,7 @@ where
         if res_cnt > 0 {
             // these are safe to unwrap due to the res_cnt gate.
             let start = span_acc.first().unwrap().start;
-            let end = span_acc.first().unwrap().end;
+            let end = span_acc.last().unwrap().end;
 
             Ok(SpannedMatchStatus::new(
                 Some(start..end),
@@ -1252,7 +1252,7 @@ where
         if res_cnt == n {
             // these are safe to unwrap due to the res_cnt gate.
             let start = span_acc.first().unwrap().start;
-            let end = span_acc.first().unwrap().end;
+            let end = span_acc.last().unwrap().end;
 
             Ok(SpannedMatchStatus::new(
                 Some(start..end),
@@ -1552,8 +1552,16 @@ where
             Some(span),
             MatchStatus::Match((next_input, Some(res))),
         )),
+
         Ok(SpannedMatchStatus {
-            span: span,
+            span: None,
+            match_status: MatchStatus::Match((next_input, res)),
+        }) => Ok(SpannedMatchStatus::new(
+            None,
+            MatchStatus::Match((next_input, Some(res))),
+        )),
+        Ok(SpannedMatchStatus {
+            span,
             match_status: MatchStatus::NoMatch(last_input),
         }) => Ok(SpannedMatchStatus::new(
             span,
@@ -1602,7 +1610,7 @@ where
                 (_, MatchStatus::NoMatch(_)) => {
                     Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input)))
                 }
-                (span, MatchStatus::Match((p1_input, result1))) => {
+                (_, MatchStatus::Match((p1_input, result1))) => {
                     parser2.parse(p1_input).map(|p2_sms| {
                         match (p2_sms.as_span(), p2_sms.unwrap()) {
                             (_, MatchStatus::NoMatch(_)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,12 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], 'b'))),
+    ///   Ok(SpannedMatchStatus{
+    ///     span: Some(0..2),
+    ///     match_status: MatchStatus::Match((&input[2..], 'b'))
+    ///   }),
     ///   expect_character('a')
     ///       .and_then(|_| expect_character('b')).parse(&input)
     /// );

--- a/src/parsers/byte/mod.rs
+++ b/src/parsers/byte/mod.rs
@@ -24,10 +24,13 @@ use crate::prelude::v1::*;
 ///   expect_byte(0x02).parse(&input)
 /// );
 /// ```
-pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [u8], u8> {
-    move |input: &'a [u8]| match input.get(0) {
-        Some(&next) if next == expected => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
+pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
+    move |input: &'a [(usize, u8)]| match input.get(0) {
+        Some(&(pos, next)) if next == expected => Ok(SpannedMatchStatus::new(
+            Some(pos..pos + 1),
+            MatchStatus::Match((&input[1..], next)),
+        )),
+        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
     }
 }
 
@@ -56,9 +59,12 @@ pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [u8], u8> {
 ///   any_byte().parse(&input[0..])
 /// );
 /// ```
-pub fn any_byte<'a>() -> impl Parser<'a, &'a [u8], u8> {
-    move |input: &'a [u8]| match input.get(0) {
-        Some(&next) => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
+pub fn any_byte<'a>() -> impl Parser<'a, &'a [(usize, u8)], u8> {
+    move |input: &'a [(usize, u8)]| match input.get(0) {
+        Some(&(pos, next)) => Ok(SpannedMatchStatus::new(
+            Some(pos..pos + 1),
+            MatchStatus::Match((&input[1..], next)),
+        )),
+        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
     }
 }

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -2,3 +2,4 @@ pub use crate::BoxedParser;
 pub use crate::MatchStatus;
 pub use crate::ParseResult;
 pub use crate::Parser;
+pub use crate::SpannedMatchStatus;

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -4,83 +4,113 @@ use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 0x00))
+        }),
         expect_byte(0x00).parse(&input)
     );
 }
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0xFF).skip().parse(&input)
     );
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[4..],
-            vec![0x00, 0x00, 0x00, 0x00]
-        ))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..4),
+            match_status: MatchStatus::Match((&input[4..], vec![0x00, 0x00, 0x00, 0x00]))
+        }),
         take_until_n(expect_byte(0x00), 4).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))
+        }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input = vec![0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..2),
+            match_status: MatchStatus::Match((&input[2..], vec![0x00, 0x00]))
+        }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0x03).take_until_n(2).parse(&input)
     );
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0x03).take_n(2).parse(&input)
     );
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -4,104 +4,143 @@ use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 'a'))
+        }),
         expect_character('a').parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('x').skip().parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_can_match_with_one_of() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     let parsers = vec![
         expect_character('b'),
         expect_character('c'),
         expect_character('a'),
     ];
+
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 'a'))
+        }),
         crate::one_of(parsers).parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..4),
+            match_status: MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))
+        }),
         take_until_n(expect_character('a'), 4).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input = vec!['a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..2),
+            match_status: MatchStatus::Match((&input[2..], vec!['a', 'a']))
+        }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('d').take_until_n(2).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_n_will_match_only_up_to_specified_limit() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        }),
         expect_character('a').take_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('d').take_n(2).parse(&input[0..])
     );
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input = vec!['a', 'b', 'c'];
-
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
     );
 }


### PR DESCRIPTION
# Introduction
This PR makes a breaking API change that begins adding spanned parse results to each parser and expecting enumerated input for the parse data.

# Linked Issues
#60 
# Dependencies
- [ ] Fix Doc tests
# Test
- [ ] Tested Locally
- [ ] Documented

# Review
- [ ] Ready for review
- [ ] Ready to merge

# Deployment
