### PR TITLE
Capture span data in MatchStatus

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcel"
-version = "1.9.1"
+version = "2.0.0"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 publish = false

--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -5,7 +5,7 @@ use parcel::Parser;
 
 fn parse_map(c: &mut Criterion) {
     let mut group = c.benchmark_group("map combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -24,7 +24,7 @@ fn parse_map(c: &mut Criterion) {
 
 fn parse_skip(c: &mut Criterion) {
     let mut group = c.benchmark_group("skip combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -41,7 +41,7 @@ fn parse_skip(c: &mut Criterion) {
 
 fn parse_or(c: &mut Criterion) {
     let mut group = c.benchmark_group("or combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -62,7 +62,7 @@ fn parse_or(c: &mut Criterion) {
 
 fn parse_one_of(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_of combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -79,7 +79,7 @@ fn parse_one_of(c: &mut Criterion) {
 
 fn parse_and_then(c: &mut Criterion) {
     let mut group = c.benchmark_group("and_then combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with u8 vec", |b| {
         b.iter(|| {
@@ -100,7 +100,7 @@ fn parse_and_then(c: &mut Criterion) {
 
 fn parse_peek_next(c: &mut Criterion) {
     let mut group = c.benchmark_group("peek_next combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -121,7 +121,10 @@ fn parse_peek_next(c: &mut Criterion) {
 
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
-    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -141,7 +144,10 @@ fn parse_take_until_n(c: &mut Criterion) {
 
 fn parse_take_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_n combinator");
-    let seed_vec = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -159,7 +165,7 @@ fn parse_take_n(c: &mut Criterion) {
 
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -179,7 +185,7 @@ fn parse_predicate(c: &mut Criterion) {
 
 fn parse_zero_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("zero_or_more combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -197,7 +203,7 @@ fn parse_zero_or_more(c: &mut Criterion) {
 
 fn parse_one_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_or_more combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -215,7 +221,7 @@ fn parse_one_or_more(c: &mut Criterion) {
 
 fn parse_optional(c: &mut Criterion) {
     let mut group = c.benchmark_group("optional combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
@@ -233,7 +239,7 @@ fn parse_optional(c: &mut Criterion) {
 
 fn parse_applicatives(c: &mut Criterion) {
     let mut group = c.benchmark_group("applicatives combinator");
-    let seed_vec = vec![0x00, 0x01, 0x02];
+    let seed_vec: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     group.bench_function("join combinator with byte vec", |b| {
         b.iter(|| {

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -5,7 +5,7 @@ use parcel::Parser;
 
 fn parse_map(c: &mut Criterion) {
     let mut group = c.benchmark_group("map combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -25,7 +25,7 @@ fn parse_map(c: &mut Criterion) {
 
 fn parse_skip(c: &mut Criterion) {
     let mut group = c.benchmark_group("skip combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -42,7 +42,7 @@ fn parse_skip(c: &mut Criterion) {
 
 fn parse_or(c: &mut Criterion) {
     let mut group = c.benchmark_group("or combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -63,7 +63,7 @@ fn parse_or(c: &mut Criterion) {
 
 fn parse_one_of(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_of combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -80,7 +80,7 @@ fn parse_one_of(c: &mut Criterion) {
 
 fn parse_and_then(c: &mut Criterion) {
     let mut group = c.benchmark_group("and_then combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -101,7 +101,7 @@ fn parse_and_then(c: &mut Criterion) {
 
 fn parse_peek_next(c: &mut Criterion) {
     let mut group = c.benchmark_group("peek_next combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -122,7 +122,10 @@ fn parse_peek_next(c: &mut Criterion) {
 
 fn parse_take_until_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_until_n combinator");
-    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -142,7 +145,10 @@ fn parse_take_until_n(c: &mut Criterion) {
 
 fn parse_take_n(c: &mut Criterion) {
     let mut group = c.benchmark_group("take_n combinator");
-    let seed_vec = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -160,7 +166,7 @@ fn parse_take_n(c: &mut Criterion) {
 
 fn parse_predicate(c: &mut Criterion) {
     let mut group = c.benchmark_group("predicate combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -181,7 +187,7 @@ fn parse_predicate(c: &mut Criterion) {
 
 fn parse_zero_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("zero_or_more combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -201,7 +207,7 @@ fn parse_zero_or_more(c: &mut Criterion) {
 
 fn parse_one_or_more(c: &mut Criterion) {
     let mut group = c.benchmark_group("one_or_more combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -221,7 +227,7 @@ fn parse_one_or_more(c: &mut Criterion) {
 
 fn parse_optional(c: &mut Criterion) {
     let mut group = c.benchmark_group("optional combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
@@ -239,7 +245,7 @@ fn parse_optional(c: &mut Criterion) {
 
 fn parse_applicatives(c: &mut Criterion) {
     let mut group = c.benchmark_group("applicatives combinator");
-    let seed_vec = vec!['a', 'b', 'c'];
+    let seed_vec: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     group.bench_function("join combinator with char vec", |b| {
         b.iter(|| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,27 +14,6 @@ use std::borrow::Borrow;
 
 pub type Span = std::ops::Range<usize>;
 
-/// SpannedMatchStatus stores an offset of a matching pattern along with it's corresponding match.
-#[derive(Debug, Clone, PartialEq)]
-pub struct SpannedMatchStatus<U, T> {
-    span: Option<Span>,
-    match_status: MatchStatus<U, T>,
-}
-
-impl<U, T> SpannedMatchStatus<U, T> {
-    pub fn new(span: Option<Span>, match_status: MatchStatus<U, T>) -> Self {
-        Self { span, match_status }
-    }
-
-    pub fn as_span(&self) -> Option<Span> {
-        self.span.clone()
-    }
-
-    pub fn unwrap(self) -> MatchStatus<U, T> {
-        self.match_status
-    }
-}
-
 /// MatchStatus represents a non-error parser result with two cases, signifying
 /// whether the parse returned a match or not.
 #[derive(Debug, PartialEq, Clone)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,13 +32,13 @@ impl<U, T> MatchStatus<U, T> {
     /// # Examples
     ///
     /// ```
-    /// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
+    /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::<&[char], char>::Match{span: 0..1, remainder: &input[1..], inner: 'a'};
     /// assert_eq!(v.unwrap(), 'a');
     /// ```
     ///
     /// ```{.should_panic}
-    /// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
+    /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::<&[char], char>::NoMatch(&input);
     /// assert_eq!(v.unwrap(), 'a');
     /// ```
@@ -62,7 +62,7 @@ impl<U, T> MatchStatus<U, T> {
     /// # Examples
     ///
     /// ```
-    /// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
+    /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::NoMatch(&input);
     /// assert_eq!(v.unwrap_or('b'), 'b');
     /// ```
@@ -82,7 +82,7 @@ impl<U, T> MatchStatus<U, T> {
     /// # Examples
     ///
     /// ```
-    /// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
+    /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::NoMatch(&input);
     /// assert_eq!(v.unwrap_or_else(|| 'b'), 'b');
     /// ```
@@ -105,9 +105,9 @@ impl<U, T> MatchStatus<U, T> {
     /// # Examples
     ///
     /// ```
-    /// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
+    /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::<&[char], char>::Match{span: 0..1, remainder: &input[1..], inner: 'a'};
-    /// assert_eq!(v.as_span(), 0..1);
+    /// assert_eq!(v.as_span(), Some(0..1));
     /// ```
     pub fn as_span(&self) -> Option<Span> {
         match self {
@@ -183,7 +183,7 @@ pub trait Parser<'a, Input, Output> {
     /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: 'b'}),
-    ///   expect_character('a').and_then(|| expect_character('b')).parse(&input)
+    ///   expect_character('a').and_then(|_| expect_character('b')).parse(&input)
     /// );
     /// ```
     ///
@@ -192,7 +192,7 @@ pub trait Parser<'a, Input, Output> {
     /// use parcel::parsers::character::expect_character;
     /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: 'ab'.to_string()}),
+    ///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: "ab".to_string()}),
     ///   expect_character('a').and_then(
     ///       |first_match| expect_character('b').map(move |second_match| {
     ///          format!("{}{}", first_match, second_match)
@@ -243,9 +243,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///     Ok(MatchStatus::Match((&input[1..], 'a'))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
     ///     expect_character('a')
     ///         .peek_next(expect_character('b'))
     ///         .parse(&input[0..])
@@ -255,7 +255,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
     ///     Ok(MatchStatus::NoMatch(&input[0..])),
     ///     expect_character('a')
@@ -267,9 +267,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///     Ok(MatchStatus::Match((&input[1..], 0x00))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
     ///     expect_byte(0x00)
     ///         .peek_next(expect_byte(0x01))
     ///         .parse(&input[0..])
@@ -279,7 +279,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
     ///     Ok(MatchStatus::NoMatch(&input[0..])),
     ///     expect_byte(0x00)
@@ -307,9 +307,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'a', 'a'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'a', 'a'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
     ///   expect_character('a').take_until_n(2).parse(&input)
     /// );
     /// ```
@@ -317,9 +317,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], vec!['a']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: vec!['a']}),
     ///   expect_character('a').take_until_n(2).parse(&input)
     /// );
     /// ```
@@ -327,9 +327,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x00, 0x00];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
     ///   expect_byte(0x00).take_until_n(2).parse(&input)
     /// );
     /// ```
@@ -337,9 +337,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], vec![0x00]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: vec![0x00]}),
     ///   expect_byte(0x00).take_until_n(2).parse(&input)
     /// );
     /// ```
@@ -362,9 +362,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'a', 'a'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'a', 'a'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
     ///   expect_character('a').take_n(2).parse(&input)
     /// );
     /// ```
@@ -372,7 +372,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
     ///   expect_character('a').take_n(2).parse(&input)
@@ -382,9 +382,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x00, 0x00];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
     ///   expect_byte(0x00).take_n(2).parse(&input)
     /// );
     /// ```
@@ -392,7 +392,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
     ///   expect_byte(0x00).take_n(2).parse(&input)
@@ -417,9 +417,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::any_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
     ///   any_character().predicate(|&c| c != 'c').parse(&input)
     /// );
     /// ```
@@ -427,9 +427,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::any_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'b']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'b']}),
     ///   parcel::one_or_more(
     ///       any_character().predicate(|&c| c != 'c')
     ///   ).parse(&input)
@@ -439,9 +439,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::any_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
     ///   any_byte().predicate(|&b| b != 0x02).parse(&input)
     /// );
     /// ```
@@ -449,9 +449,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::any_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x01]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x01]}),
     ///   parcel::one_or_more(
     ///       any_byte().predicate(|&b| b != 0x02)
     ///   ).parse(&input)
@@ -475,9 +475,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'a', 'b'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'a', 'b'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
     ///   expect_character('a').zero_or_more().parse(&input)
     /// );
     /// ```
@@ -485,9 +485,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: vec![]}),
     ///   expect_character('c').zero_or_more().parse(&input)
     /// );
     /// ```
@@ -495,9 +495,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x00, 0x01];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
     ///   expect_byte(0x00).zero_or_more().parse(&input)
     /// );
     /// ```
@@ -505,9 +505,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: vec![]}),
     ///   expect_byte(0x02).zero_or_more().parse(&input)
     /// );
     /// ```
@@ -528,9 +528,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'a', 'b'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'a', 'b'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
     ///   expect_character('a').one_or_more().parse(&input)
     /// );
     /// ```
@@ -538,7 +538,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
     ///   expect_character('c').one_or_more().parse(&input)
@@ -548,9 +548,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x00, 0x01];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
     ///   expect_byte(0x00).one_or_more().parse(&input)
     /// );
     /// ```
@@ -558,7 +558,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
     ///   expect_byte(0x02).one_or_more().parse(&input)
@@ -581,9 +581,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'a', 'b'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], "a".to_string()))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: "a".to_string()}),
     ///   expect_character('a').map(
     ///       |res| format!("{}", res)
     ///   ).parse(&input)
@@ -593,9 +593,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], "0".to_string()))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: "0".to_string()}),
     ///   expect_byte(0x00).map(
     ///       |res| format!("{}", res)
     ///   ).parse(&input)
@@ -621,7 +621,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
     ///   expect_character('a').skip().parse(&input)
@@ -631,7 +631,7 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
     ///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
     ///   expect_byte(0x00).skip().parse(&input)
@@ -655,9 +655,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], Some('a')))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: Some('a')}),
     ///   expect_character('a').optional().parse(&input)
     /// );
     /// ```
@@ -665,9 +665,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: None}),
     ///   expect_character('c').optional().parse(&input)
     /// );
     /// ```
@@ -675,9 +675,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[1..], Some(0x00)))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: Some(0x00)}),
     ///   expect_byte(0x00).optional().parse(&input)
     /// );
     /// ```
@@ -685,9 +685,9 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::byte::expect_byte;
-    /// let input = vec![0x00, 0x01, 0x02];
+    /// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+    ///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: None}),
     ///   expect_byte(0x02).optional().parse(&input)
     /// );
     /// ```
@@ -748,9 +748,9 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   parcel::or(expect_character('b'), || expect_character('a')).parse(&input)
 /// );
 /// ```
@@ -758,9 +758,9 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   parcel::or(expect_byte(0x01), || expect_byte(0x00)).parse(&input)
 /// );
 /// ```
@@ -803,10 +803,10 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// let parsers = vec![expect_character('b'), expect_character('c'), expect_character('a')];
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   parcel::one_of(parsers).parse(&input)
 /// );
 /// ```
@@ -814,10 +814,10 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// let parsers = vec![expect_byte(0x01), expect_byte(0x02), expect_byte(0x00)];
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   parcel::one_of(parsers).parse(&input)
 /// );
 /// ```
@@ -855,9 +855,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], "a".to_string()))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: "a".to_string()}),
 ///   parcel::map(
 ///       expect_character('a'),
 ///       |res| format!("{}", res)
@@ -868,9 +868,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], "0".to_string()))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: "0".to_string()}),
 ///   parcel::map(
 ///       expect_byte(0x00),
 ///       |res| format!("{}", res)
@@ -906,7 +906,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
 ///   parcel::skip(expect_character('a')).parse(&input)
@@ -916,7 +916,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[1..])),
 ///   parcel::skip(expect_byte(0x00)).parse(&input)
@@ -946,9 +946,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 'b'))),
+///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: 'b'}),
 ///   parcel::and_then(
 ///       expect_character('a'),
 ///       |_| expect_character('b'),
@@ -959,9 +959,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], "ab".to_string()))),
+///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: "ab".to_string()}),
 ///   parcel::and_then(
 ///       expect_character('a'),
 ///       |first_match| expect_character('b').map(move |second_match| {
@@ -973,9 +973,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: 0x01}),
 ///   parcel::and_then(
 ///       expect_byte(0x00),
 ///       |_| expect_byte(0x01),
@@ -986,9 +986,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], "01".to_string()))),
+///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: "01".to_string()}),
 ///   parcel::and_then(
 ///       expect_byte(0x00),
 ///       |first_match| expect_byte(0x01).map(move |second_match| {
@@ -1026,9 +1026,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   parcel::peek_next(
 ///       expect_character('a'),
 ///       expect_character('b'),
@@ -1039,7 +1039,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::peek_next(
@@ -1052,9 +1052,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   parcel::peek_next(
 ///       expect_byte(0x00),
 ///       expect_byte(0x01),
@@ -1065,7 +1065,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::peek_next(
@@ -1118,9 +1118,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'a', 'a'];
+/// let input: Vec<(usize, char)> = vec!['a', 'a', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
 ///   parcel::take_until_n(expect_character('a'), 2).parse(&input)
 /// );
 /// ```
@@ -1128,9 +1128,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], vec!['a']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: vec!['a']}),
 ///   parcel::take_until_n(expect_character('a'), 2).parse(&input)
 /// );
 /// ```
@@ -1138,9 +1138,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x00, 0x00];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
 ///   parcel::take_until_n(expect_byte(0x00), 2).parse(&input)
 /// );
 /// ```
@@ -1149,8 +1149,9 @@ where
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
 /// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], vec![0x00]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: vec![0x00]}),
 ///   parcel::take_until_n(expect_byte(0x00), 2).parse(&input)
 /// );
 /// ```
@@ -1205,9 +1206,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'a', 'a'];
+/// let input: Vec<(usize, char)> = vec!['a', 'a', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
 ///   parcel::take_n(expect_character('a'), 2).parse(&input)
 /// );
 /// ```
@@ -1215,7 +1216,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::take_n(expect_character('a'), 2).parse(&input)
@@ -1225,9 +1226,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x00, 0x00];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
 ///   parcel::take_n(expect_byte(0x00), 2).parse(&input)
 /// );
 /// ```
@@ -1235,7 +1236,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::take_n(expect_byte(0x00), 2).parse(&input)
@@ -1294,9 +1295,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::any_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   parcel::predicate(any_character(), |&c| c != 'c').parse(&input)
 /// );
 /// ```
@@ -1304,9 +1305,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::any_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'b']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'b']}),
 ///   parcel::one_or_more(
 ///       parcel::predicate(any_character(), |&c| c != 'c')
 ///   ).parse(&input)
@@ -1316,9 +1317,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::any_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   parcel::predicate(any_byte(), |&b| b != 0x02).parse(&input)
 /// );
 /// ```
@@ -1326,9 +1327,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::any_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x01]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x01]}),
 ///   parcel::one_or_more(
 ///       parcel::predicate(any_byte(), |&b| b != 0x02)
 ///   ).parse(&input)
@@ -1367,9 +1368,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'a', 'b'];
+/// let input: Vec<(usize, char)> = vec!['a', 'a', 'b'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
 ///   parcel::zero_or_more(expect_character('a')).parse(&input)
 /// );
 /// ```
@@ -1377,9 +1378,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: vec![]}),
 ///   parcel::zero_or_more(expect_character('c')).parse(&input)
 /// );
 /// ```
@@ -1387,9 +1388,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x00, 0x01];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
 ///   parcel::zero_or_more(expect_byte(0x00)).parse(&input)
 /// );
 /// ```
@@ -1397,9 +1398,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[0..], vec![]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: vec![]}),
 ///   parcel::zero_or_more(expect_byte(0x02)).parse(&input)
 /// );
 /// ```
@@ -1450,9 +1451,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'a', 'b'];
+/// let input: Vec<(usize, char)> = vec!['a', 'a', 'b'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec!['a', 'a']}),
 ///   parcel::one_or_more(expect_character('a')).parse(&input)
 /// );
 /// ```
@@ -1460,7 +1461,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::one_or_more(expect_character('c')).parse(&input)
@@ -1470,9 +1471,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x00, 0x01];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: vec![0x00, 0x00]}),
 ///   parcel::one_or_more(expect_byte(0x00)).parse(&input)
 /// );
 /// ```
@@ -1480,7 +1481,7 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   parcel::one_or_more(expect_byte(0x02)).parse(&input)
@@ -1530,9 +1531,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], Some('a')))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: Some('a')}),
 ///   parcel::optional(expect_character('a')).parse(&input)
 /// );
 /// ```
@@ -1540,9 +1541,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: None}),
 ///   parcel::optional(expect_character('c')).parse(&input)
 /// );
 /// ```
@@ -1550,9 +1551,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], Some(0x00)))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: Some(0x00)}),
 ///   parcel::optional(expect_byte(0x00)).parse(&input)
 /// );
 /// ```
@@ -1560,9 +1561,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[0..], None))),
+///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: None}),
 ///   parcel::optional(expect_byte(0x02)).parse(&input)
 /// );
 /// ```
@@ -1600,9 +1601,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], ('a', 'b')))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: ('a', 'b')}),
 ///   parcel::join(expect_character('a'), expect_character('b')).parse(&input)
 /// );
 /// ```
@@ -1610,9 +1611,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], (0x00, 0x01)))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: (0x00, 0x01)}),
 ///   parcel::join(expect_byte(0x00), expect_byte(0x01)).parse(&input)
 /// );
 /// ```
@@ -1653,9 +1654,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: 'a'}),
 ///   parcel::left(
 ///       parcel::join(
 ///           expect_character('a'),
@@ -1668,9 +1669,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: 0x00}),
 ///   parcel::left(
 ///       parcel::join(
 ///           expect_byte(0x00),
@@ -1697,9 +1698,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 'b'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: 'b'}),
 ///   parcel::right(
 ///       parcel::join(
 ///           expect_character('a'),
@@ -1712,9 +1713,9 @@ where
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], 0x01))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: 0x01}),
 ///   parcel::right(
 ///       parcel::join(
 ///           expect_byte(0x00),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -946,13 +946,12 @@ where
 {
     move |input| match parser.parse(input) {
         Ok(MatchStatus::Match {
-            span,
+            span: _,
             remainder,
-            inner,
+            inner: _,
         }) => Ok(MatchStatus::NoMatch(remainder)),
         Ok(MatchStatus::NoMatch(last_input)) => Ok(MatchStatus::NoMatch(last_input)),
         Err(e) => Err(e),
-        _ => Err("Invalid match type".to_string()),
     }
 }
 
@@ -1024,7 +1023,7 @@ where
     move |input| match parser.parse(input) {
         Ok(ms) => match ms {
             MatchStatus::Match {
-                span,
+                span: _,
                 remainder,
                 inner,
             } => f(inner).parse(remainder),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -993,7 +993,7 @@ where
 {
     move |input| match parser.parse(input) {
         Ok(sms) => match (sms.as_span(), sms.unwrap()) {
-            (span, MatchStatus::Match((next_input, result))) => f(result).parse(next_input),
+            (_, MatchStatus::Match((next_input, result))) => f(result).parse(next_input),
 
             (span, MatchStatus::NoMatch(last_input)) => Ok(SpannedMatchStatus::new(
                 span,
@@ -1072,7 +1072,7 @@ where
             (span, MatchStatus::Match((next_input, result))) => {
                 let first_input = next_input;
                 if let Ok(SpannedMatchStatus {
-                    span: span,
+                    span: _,
                     match_status: MatchStatus::Match(_),
                 }) = second.parse(next_input)
                 {
@@ -1165,7 +1165,7 @@ where
         if res_cnt > 0 {
             // these are safe to unwrap due to the res_cnt gate.
             let start = span_acc.first().unwrap().start;
-            let end = span_acc.first().unwrap().end;
+            let end = span_acc.last().unwrap().end;
 
             Ok(SpannedMatchStatus::new(
                 Some(start..end),
@@ -1252,7 +1252,7 @@ where
         if res_cnt == n {
             // these are safe to unwrap due to the res_cnt gate.
             let start = span_acc.first().unwrap().start;
-            let end = span_acc.first().unwrap().end;
+            let end = span_acc.last().unwrap().end;
 
             Ok(SpannedMatchStatus::new(
                 Some(start..end),
@@ -1552,8 +1552,16 @@ where
             Some(span),
             MatchStatus::Match((next_input, Some(res))),
         )),
+
         Ok(SpannedMatchStatus {
-            span: span,
+            span: None,
+            match_status: MatchStatus::Match((next_input, res)),
+        }) => Ok(SpannedMatchStatus::new(
+            None,
+            MatchStatus::Match((next_input, Some(res))),
+        )),
+        Ok(SpannedMatchStatus {
+            span,
             match_status: MatchStatus::NoMatch(last_input),
         }) => Ok(SpannedMatchStatus::new(
             span,
@@ -1602,7 +1610,7 @@ where
                 (_, MatchStatus::NoMatch(_)) => {
                     Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input)))
                 }
-                (span, MatchStatus::Match((p1_input, result1))) => {
+                (_, MatchStatus::Match((p1_input, result1))) => {
                     parser2.parse(p1_input).map(|p2_sms| {
                         match (p2_sms.as_span(), p2_sms.unwrap()) {
                             (_, MatchStatus::NoMatch(_)) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1424,7 +1424,7 @@ where
             result_acc.push(inner);
         }
 
-        if result_acc.len() > 0 {
+        if !result_acc.is_empty() {
             let start = span_acc.first().unwrap().start;
             let end = span_acc.last().unwrap().end;
 
@@ -1507,7 +1507,7 @@ where
             result_acc.push(inner);
         }
 
-        if result_acc.len() > 0 {
+        if !result_acc.is_empty() {
             let start = span_acc.first().unwrap().start;
             let end = span_acc.last().unwrap().end;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,9 +169,12 @@ pub trait Parser<'a, Input, Output> {
     /// ```
     /// use parcel::prelude::v1::*;
     /// use parcel::parsers::character::expect_character;
-    /// let input = vec!['a', 'b', 'c'];
+    /// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     /// assert_eq!(
-    ///   Ok(parcel::MatchStatus::Match((&input[2..], 'b'))),
+    ///   Ok(SpannedMatchStatus{
+    ///     span: Some(0..2),
+    ///     match_status: MatchStatus::Match((&input[2..], 'b'))
+    ///   }),
     ///   expect_character('a')
     ///       .and_then(|_| expect_character('b')).parse(&input)
     /// );

--- a/src/parsers/byte/mod.rs
+++ b/src/parsers/byte/mod.rs
@@ -13,7 +13,7 @@ use crate::prelude::v1::*;
 ///     .enumerate()
 ///     .collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00},
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   expect_byte(0x00).parse(&input)
 /// );
 /// ```
@@ -55,7 +55,7 @@ pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
 ///     .enumerate()
 ///     .collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00},
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00}),
 ///   any_byte().parse(&input)
 /// );
 /// ```

--- a/src/parsers/byte/mod.rs
+++ b/src/parsers/byte/mod.rs
@@ -24,10 +24,13 @@ use crate::prelude::v1::*;
 ///   expect_byte(0x02).parse(&input)
 /// );
 /// ```
-pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [u8], u8> {
-    move |input: &'a [u8]| match input.get(0) {
-        Some(&next) if next == expected => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
+pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
+    move |input: &'a [(usize, u8)]| match input.get(0) {
+        Some(&(pos, next)) if next == expected => Ok(SpannedMatchStatus::new(
+            Some(pos..pos + 1),
+            MatchStatus::Match((&input[1..], next)),
+        )),
+        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
     }
 }
 
@@ -56,9 +59,12 @@ pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [u8], u8> {
 ///   any_byte().parse(&input[0..])
 /// );
 /// ```
-pub fn any_byte<'a>() -> impl Parser<'a, &'a [u8], u8> {
-    move |input: &'a [u8]| match input.get(0) {
-        Some(&next) => Ok(MatchStatus::Match((&input[1..], next))),
-        _ => Ok(MatchStatus::NoMatch(input)),
+pub fn any_byte<'a>() -> impl Parser<'a, &'a [(usize, u8)], u8> {
+    move |input: &'a [(usize, u8)]| match input.get(0) {
+        Some(&(pos, next)) => Ok(SpannedMatchStatus::new(
+            Some(pos..pos + 1),
+            MatchStatus::Match((&input[1..], next)),
+        )),
+        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
     }
 }

--- a/src/parsers/byte/mod.rs
+++ b/src/parsers/byte/mod.rs
@@ -8,9 +8,12 @@ use crate::prelude::v1::*;
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
+///     .into_iter()
+///     .enumerate()
+///     .collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00},
 ///   expect_byte(0x00).parse(&input)
 /// );
 /// ```
@@ -18,7 +21,10 @@ use crate::prelude::v1::*;
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::expect_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
+///     .into_iter()
+///     .enumerate()
+///     .collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   expect_byte(0x02).parse(&input)
@@ -26,11 +32,12 @@ use crate::prelude::v1::*;
 /// ```
 pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
     move |input: &'a [(usize, u8)]| match input.get(0) {
-        Some(&(pos, next)) if next == expected => Ok(SpannedMatchStatus::new(
-            Some(pos..pos + 1),
-            MatchStatus::Match((&input[1..], next)),
-        )),
-        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
+        Some(&(pos, next)) if next == expected => Ok(MatchStatus::Match {
+            span: pos..pos + 1,
+            remainder: &input[1..],
+            inner: next,
+        }),
+        _ => Ok(MatchStatus::NoMatch(input)),
     }
 }
 
@@ -43,9 +50,12 @@ pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::byte::any_byte;
-/// let input = vec![0x00, 0x01, 0x02];
+/// let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
+///     .into_iter()
+///     .enumerate()
+///     .collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 0x00))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 0x00},
 ///   any_byte().parse(&input)
 /// );
 /// ```
@@ -61,10 +71,11 @@ pub fn expect_byte<'a>(expected: u8) -> impl Parser<'a, &'a [(usize, u8)], u8> {
 /// ```
 pub fn any_byte<'a>() -> impl Parser<'a, &'a [(usize, u8)], u8> {
     move |input: &'a [(usize, u8)]| match input.get(0) {
-        Some(&(pos, next)) => Ok(SpannedMatchStatus::new(
-            Some(pos..pos + 1),
-            MatchStatus::Match((&input[1..], next)),
-        )),
-        _ => Ok(SpannedMatchStatus::new(None, MatchStatus::NoMatch(input))),
+        Some(&(pos, next)) => Ok(MatchStatus::Match {
+            span: pos..pos + 1,
+            remainder: &input[1..],
+            inner: next,
+        }),
+        _ => Ok(MatchStatus::NoMatch(input)),
     }
 }

--- a/src/parsers/character/mod.rs
+++ b/src/parsers/character/mod.rs
@@ -1,4 +1,5 @@
 use crate::prelude::v1::*;
+
 /// Matches a single provided character, returning match if the next character
 /// in the array matches the expected value. Otherwise, a `NoMatch` is
 /// returned.
@@ -8,9 +9,9 @@ use crate::prelude::v1::*;
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   expect_character('a').parse(&input)
 /// );
 /// ```
@@ -18,7 +19,7 @@ use crate::prelude::v1::*;
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   expect_character('b').parse(&input)
@@ -44,9 +45,9 @@ pub fn expect_character<'a>(expected: char) -> impl Parser<'a, &'a [(usize, char
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::any_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   any_character().parse(&input)
 /// );
 /// ```
@@ -81,9 +82,9 @@ pub fn any_character<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::any_non_whitespace_character;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   any_non_whitespace_character().parse(&input)
 /// );
 /// ```
@@ -91,7 +92,7 @@ pub fn any_character<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::any_non_whitespace_character;
-/// let input = vec![' '];
+/// let input: Vec<(usize, char)> = vec![' '].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   any_non_whitespace_character().parse(&input[0..])
@@ -126,9 +127,9 @@ pub fn any_non_whitespace_character<'a>() -> impl Parser<'a, &'a [(usize, char)]
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_str;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], "ab".to_string()))),
+///   Ok(parcel::MatchStatus::Match{span: 0..2, remainder: &input[2..], inner: "ab".to_string()}),
 ///   expect_str("ab").parse(&input)
 /// );
 /// ```
@@ -136,7 +137,7 @@ pub fn any_non_whitespace_character<'a>() -> impl Parser<'a, &'a [(usize, char)]
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::expect_str;
-/// let input = vec!['a', 'b', 'c'];
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   expect_str("b").parse(&input)
@@ -167,9 +168,9 @@ pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [(usize, ch
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::non_newline_whitespace;
-/// let input = vec![' ', '\t', 'a'];
+/// let input: Vec<(usize, char)> = vec![' ', '\t', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[2..], '\t'))),
+///   Ok(parcel::MatchStatus::Match{span: 1..2, remainder: &input[2..], inner: '\t'}),
 ///   non_newline_whitespace().and_then(|_| non_newline_whitespace()).parse(&input)
 /// );
 /// ```
@@ -177,7 +178,7 @@ pub fn expect_str<'a>(expected: &'static str) -> impl Parser<'a, &'a [(usize, ch
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::non_newline_whitespace;
-/// let input = vec!['\n'];
+/// let input: Vec<(usize, char)> = vec!['\n'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   non_newline_whitespace().parse(&input)
@@ -194,9 +195,9 @@ pub fn non_newline_whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::space;
-/// let input = vec![' ', 'a'];
+/// let input: Vec<(usize, char)> = vec![' ', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], ' '))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: ' '}),
 ///   space().parse(&input)
 /// );
 /// ```
@@ -204,7 +205,7 @@ pub fn non_newline_whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::space;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   space().parse(&input)
@@ -221,9 +222,9 @@ pub fn space<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::tab;
-/// let input = vec!['\t', 'a'];
+/// let input: Vec<(usize, char)> = vec!['\t', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], '\t'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: '\t'}),
 ///   tab().parse(&input)
 /// );
 /// ```
@@ -231,7 +232,7 @@ pub fn space<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::tab;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   tab().parse(&input)
@@ -250,9 +251,9 @@ pub fn tab<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::whitespace;
-/// let input = vec![' ', '\n', '\t', 'a'];
+/// let input: Vec<(usize, char)> = vec![' ', '\n', '\t', 'a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[3..], '\t'))),
+///   Ok(parcel::MatchStatus::Match{span: 2..3, remainder: &input[3..], inner: '\t'}),
 ///   whitespace()
 ///     .and_then(|_| whitespace())
 ///     .and_then(|_| whitespace())
@@ -263,7 +264,7 @@ pub fn tab<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::whitespace;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   whitespace().parse(&input)
@@ -293,7 +294,7 @@ pub fn whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// use parcel::parsers::character::eof;
 /// let input = vec![];
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[0..], ' '))),
+///   Ok(parcel::MatchStatus::Match{span: 0..0, remainder: &input[0..], inner: ' '}),
 ///   eof().parse(&input)
 /// );
 /// ```
@@ -301,7 +302,7 @@ pub fn whitespace<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::eof;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   eof().parse(&input)
@@ -325,9 +326,9 @@ pub fn eof<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::newline;
-/// let input = vec!['\n'];
+/// let input: Vec<(usize, char)> = vec!['\n'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], '\n'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: '\n'}),
 ///   newline().parse(&input)
 /// );
 /// ```
@@ -335,7 +336,7 @@ pub fn eof<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::newline;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   newline().parse(&input)
@@ -353,9 +354,9 @@ pub fn newline<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::alphabetic;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   alphabetic().parse(&input)
 /// );
 /// ```
@@ -363,7 +364,7 @@ pub fn newline<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::alphabetic;
-/// let input = vec!['\n'];
+/// let input: Vec<(usize, char)> = vec!['\n'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   alphabetic().parse(&input)
@@ -392,9 +393,9 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::digit;
-/// let input = vec!['a'];
+/// let input: Vec<(usize, char)> = vec!['a'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], 'a'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
 ///   digit(16).parse(&input)
 /// );
 /// ```
@@ -402,9 +403,9 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::digit;
-/// let input = vec!['9'];
+/// let input: Vec<(usize, char)> = vec!['9'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], '9'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: '9'}),
 ///   digit(10).parse(&input)
 /// );
 /// ```
@@ -412,9 +413,9 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::digit;
-/// let input = vec!['7'];
+/// let input: Vec<(usize, char)> = vec!['7'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], '7'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: '7'}),
 ///   digit(8).parse(&input)
 /// );
 /// ```
@@ -422,9 +423,9 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::digit;
-/// let input = vec!['1'];
+/// let input: Vec<(usize, char)> = vec!['1'].into_iter().enumerate().collect();
 /// assert_eq!(
-///   Ok(parcel::MatchStatus::Match((&input[1..], '1'))),
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: '1'}),
 ///   digit(2).parse(&input)
 /// );
 /// ```
@@ -432,7 +433,7 @@ pub fn alphabetic<'a>() -> impl Parser<'a, &'a [(usize, char)], char> {
 /// ```
 /// use parcel::prelude::v1::*;
 /// use parcel::parsers::character::digit;
-/// let input = vec!['\n'];
+/// let input: Vec<(usize, char)> = vec!['\n'].into_iter().enumerate().collect();
 /// assert_eq!(
 ///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
 ///   digit(16).parse(&input)

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -2,3 +2,4 @@ pub use crate::BoxedParser;
 pub use crate::MatchStatus;
 pub use crate::ParseResult;
 pub use crate::Parser;
+pub use crate::SpannedMatchStatus;

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -2,4 +2,3 @@ pub use crate::BoxedParser;
 pub use crate::MatchStatus;
 pub use crate::ParseResult;
 pub use crate::Parser;
-pub use crate::SpannedMatchStatus;

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -4,83 +4,113 @@ use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_byte_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 0x00))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 0x00))
+        }),
         expect_byte(0x00).parse(&input)
     );
 }
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0xFF).skip().parse(&input)
     );
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((
-            &input[4..],
-            vec![0x00, 0x00, 0x00, 0x00]
-        ))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..4),
+            match_status: MatchStatus::Match((&input[4..], vec![0x00, 0x00, 0x00, 0x00]))
+        }),
         take_until_n(expect_byte(0x00), 4).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))
+        }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input = vec![0x00, 0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec![0x00, 0x00]))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..2),
+            match_status: MatchStatus::Match((&input[2..], vec![0x00, 0x00]))
+        }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0x03).take_until_n(2).parse(&input)
     );
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_byte(0x03).take_n(2).parse(&input)
     );
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input = vec![0x00, 0x01, 0x02];
+    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
     );
 }

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -7,9 +7,10 @@ fn parser_should_parse_byte_match() {
     let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..1),
-            match_status: MatchStatus::Match((&input[1..], 0x00))
+        Ok(MatchStatus::Match {
+            span: 0..1,
+            remainder: &input[1..],
+            inner: 0x00
         }),
         expect_byte(0x00).parse(&input)
     );
@@ -20,10 +21,7 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
     let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0xFF).skip().parse(&input)
     );
 }
@@ -36,9 +34,10 @@ fn parser_can_match_with_take_until_n() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..4),
-            match_status: MatchStatus::Match((&input[4..], vec![0x00, 0x00, 0x00, 0x00]))
+        Ok(MatchStatus::Match {
+            span: 0..4,
+            remainder: &input[4..],
+            inner: vec![0x00, 0x00, 0x00, 0x00]
         }),
         take_until_n(expect_byte(0x00), 4).parse(&input)
     );
@@ -52,9 +51,10 @@ fn take_until_n_will_match_only_up_to_specified_limit() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..3),
-            match_status: MatchStatus::Match((&input[3..], vec![0x00, 0x00, 0x00]))
+        Ok(MatchStatus::Match {
+            span: 0..3,
+            remainder: &input[3..],
+            inner: vec![0x00, 0x00, 0x00]
         }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
@@ -68,9 +68,10 @@ fn take_until_n_will_return_as_many_matches_as_possible() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..2),
-            match_status: MatchStatus::Match((&input[2..], vec![0x00, 0x00]))
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: vec![0x00, 0x00]
         }),
         expect_byte(0x00).take_until_n(3).parse(&input)
     );
@@ -81,10 +82,7 @@ fn take_until_n_returns_a_no_match_on_no_match() {
     let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0x03).take_until_n(2).parse(&input)
     );
 }
@@ -94,10 +92,7 @@ fn take_n_returns_a_no_match_on_no_match() {
     let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_byte(0x03).take_n(2).parse(&input)
     );
 }
@@ -107,10 +102,7 @@ fn predicate_should_not_match_if_case_is_true() {
     let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_byte(), |&c| c != 0x00).parse(&input)
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -4,104 +4,143 @@ use crate::{predicate, take_until_n};
 
 #[test]
 fn parser_should_parse_char_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 'a'))
+        }),
         expect_character('a').parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('x').skip().parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_can_match_with_one_of() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     let parsers = vec![
         expect_character('b'),
         expect_character('c'),
         expect_character('a'),
     ];
+
     assert_eq!(
-        Ok(MatchStatus::Match((&input[1..], 'a'))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..1),
+            match_status: MatchStatus::Match((&input[1..], 'a'))
+        }),
         crate::one_of(parsers).parse(&input[0..])
     );
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..4),
+            match_status: MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))
+        }),
         take_until_n(expect_character('a'), 4).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input = vec!['a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[2..], vec!['a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..2),
+            match_status: MatchStatus::Match((&input[2..], vec!['a', 'a']))
+        }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('d').take_until_n(2).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_n_will_match_only_up_to_specified_limit() {
-    let input = vec!['a', 'a', 'a', 'a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
+        .into_iter()
+        .enumerate()
+        .collect();
 
     assert_eq!(
-        Ok(MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))),
+        Ok(SpannedMatchStatus {
+            span: Some(0..3),
+            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        }),
         expect_character('a').take_n(3).parse(&input[0..])
     );
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input = vec!['a', 'b', 'c'];
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         expect_character('d').take_n(2).parse(&input[0..])
     );
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input = vec!['a', 'b', 'c'];
-
+    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
+        Ok(SpannedMatchStatus {
+            span: None,
+            match_status: MatchStatus::NoMatch(&input[0..])
+        }),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
     );
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -7,9 +7,10 @@ fn parser_should_parse_char_match() {
     let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..1),
-            match_status: MatchStatus::Match((&input[1..], 'a'))
+        Ok(MatchStatus::Match {
+            span: 0..1,
+            remainder: &input[1..],
+            inner: 'a'
         }),
         expect_character('a').parse(&input[0..])
     );
@@ -20,10 +21,7 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
     let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_character('x').skip().parse(&input[0..])
     );
 }
@@ -38,9 +36,10 @@ fn parser_can_match_with_one_of() {
     ];
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..1),
-            match_status: MatchStatus::Match((&input[1..], 'a'))
+        Ok(MatchStatus::Match {
+            span: 0..1,
+            remainder: &input[1..],
+            inner: 'a'
         }),
         crate::one_of(parsers).parse(&input[0..])
     );
@@ -54,9 +53,10 @@ fn parser_can_match_with_take_until_n() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..4),
-            match_status: MatchStatus::Match((&input[4..], vec!['a', 'a', 'a', 'a']))
+        Ok(MatchStatus::Match {
+            span: 0..4,
+            remainder: &input[4..],
+            inner: vec!['a', 'a', 'a', 'a']
         }),
         take_until_n(expect_character('a'), 4).parse(&input[0..])
     );
@@ -70,9 +70,10 @@ fn take_until_n_will_match_only_up_to_specified_limit() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..3),
-            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        Ok(MatchStatus::Match {
+            span: 0..3,
+            remainder: &input[3..],
+            inner: vec!['a', 'a', 'a']
         }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
@@ -83,9 +84,10 @@ fn take_until_n_will_return_as_many_matches_as_possible() {
     let input: Vec<(usize, char)> = vec!['a', 'a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..2),
-            match_status: MatchStatus::Match((&input[2..], vec!['a', 'a']))
+        Ok(MatchStatus::Match {
+            span: 0..2,
+            remainder: &input[2..],
+            inner: vec!['a', 'a']
         }),
         expect_character('a').take_until_n(3).parse(&input[0..])
     );
@@ -96,10 +98,7 @@ fn take_until_n_returns_a_no_match_on_no_match() {
     let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_character('d').take_until_n(2).parse(&input[0..])
     );
 }
@@ -112,9 +111,10 @@ fn take_n_will_match_only_up_to_specified_limit() {
         .collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: Some(0..3),
-            match_status: MatchStatus::Match((&input[3..], vec!['a', 'a', 'a']))
+        Ok(MatchStatus::Match {
+            span: 0..3,
+            remainder: &input[3..],
+            inner: vec!['a', 'a', 'a']
         }),
         expect_character('a').take_n(3).parse(&input[0..])
     );
@@ -125,10 +125,7 @@ fn take_n_returns_a_no_match_on_no_match() {
     let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
 
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         expect_character('d').take_n(2).parse(&input[0..])
     );
 }
@@ -137,10 +134,7 @@ fn take_n_returns_a_no_match_on_no_match() {
 fn predicate_should_not_match_if_case_is_true() {
     let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     assert_eq!(
-        Ok(SpannedMatchStatus {
-            span: None,
-            match_status: MatchStatus::NoMatch(&input[0..])
-        }),
+        Ok(MatchStatus::NoMatch(&input[0..])),
         predicate(any_character(), |&c| c != 'a').parse(&input[0..])
     );
 }


### PR DESCRIPTION
# Introduction
This PR introduces a breaking api change to add span data to the MatchStatus::Match variant. This breaks the previous API.
# Linked Issues
resolves #60 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [ ] Ready to merge

# Deployment
