### PR TITLE
Remove references to "toy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <!-- /TOC -->
 
 ## General
-A toy parser combinator library for rust.
+A parser combinator library for rust.
 
 ## Warnings
 Please nobody use this. This is entirely an experiment to support insane restrictions I've imposed on myself to build a computer from first principles.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-//! This crate functions as a test/toy implementation of parser combinators in
-//! rust, heavily inspired by the article by Bodil Stokke. While the goal of
-//! this crate is to be functional for both text and binary grammars I'd highly
+//! This crate functions as an implementation of parser combinators in rust,
+//! heavily inspired by the article by Bodil Stokke. While the goal of this
+//! crate is to be functional for both text and binary grammars I'd highly
 //! recommend against using it for anything other than experimentation.
 //! Instead, recommending Geal/nom.
 


### PR DESCRIPTION
# Introduction
This is a small refactor PR to stop calling this a toy library as it's been doing some fairly heavy lifting.

# Linked Issues
resolves #89 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
