### PR TITLE
Experiment with associated type return values for combinators

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -734,6 +734,28 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
     }
 }
 
+/// Provides a short-circuiting or combinator taking a parser (P1) as an
+/// argument and a second parser (P2), provided via a closure thunk to prevent
+/// infinitely recursing.
+///
+/// The second parser passed to `or` is lazily evaluated, Only if the first case
+/// fails. This functions as a way to work around instances of Opaque types that
+/// that could lead to type issues when using an alternative, yet similar parser
+/// like `one_of`.
+///
+/// # Examples
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::Or;
+/// use parcel::parsers::character::expect_character;
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
+///
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}),
+///   Or::new(expect_character('b'), expect_character('a')).parse(&input)
+/// );
+/// ```
 #[derive(Debug)]
 pub struct Or<P1, P2> {
     p1: P1,
@@ -741,7 +763,7 @@ pub struct Or<P1, P2> {
 }
 
 impl<P1, P2> Or<P1, P2> {
-    pub fn new<P>(p1: P1, p2: P2) -> Self {
+    pub fn new(p1: P1, p2: P2) -> Self {
         Or { p1, p2 }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub trait Parser<'a, Input, Output> {
         Output: 'a,
         P: Parser<'a, Input, Output> + 'a,
     {
-        BoxedParser::new(or(self, thunk))
+        BoxedParser::new(Or::new(self, thunk()))
     }
 
     /// Returns a match if Parser<A, B> matches and then Parser<A, C> matches,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,7 +169,7 @@ pub trait Parser<'a, Input, Output> {
         Output: 'a,
         P: Parser<'a, Input, Output> + 'a,
     {
-        BoxedParser::new(Or::new(self, thunk()))
+        BoxedParser::new(or(self, thunk))
     }
 
     /// Returns a match if Parser<A, B> matches and then Parser<A, C> matches,
@@ -756,6 +756,18 @@ impl<'a, Input, Output> Parser<'a, Input, Output> for BoxedParser<'a, Input, Out
 ///   Or::new(expect_character('b'), expect_character('a')).parse(&input)
 /// );
 /// ```
+///
+/// ```
+/// use parcel::prelude::v1::*;
+/// use parcel::Or;
+/// use parcel::parsers::character::expect_character;
+/// let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
+///
+/// assert_eq!(
+///   Ok(parcel::MatchStatus::NoMatch(&input[0..])),
+///   Or::new(expect_character('b'), expect_character('c')).parse(&input)
+/// );
+/// ```
 #[derive(Debug)]
 pub struct Or<P1, P2> {
     p1: P1,
@@ -820,7 +832,7 @@ where
 ///   parcel::or(expect_byte(0x01), || expect_byte(0x00)).parse(&input)
 /// );
 /// ```
-pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
+pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> Or<P1, P2>
 where
     A: Copy + 'a + Borrow<A>,
     P1: Parser<'a, A, B>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -826,19 +826,7 @@ where
     P1: Parser<'a, A, B>,
     P2: Parser<'a, A, B>,
 {
-    move |input| match parser1.parse(input) {
-        Ok(ms) => match ms {
-            m
-            @
-            MatchStatus::Match {
-                span: _,
-                remainder: _,
-                inner: _,
-            } => Ok(m),
-            MatchStatus::NoMatch(_) => thunk_to_parser().parse(input),
-        },
-        e @ Err(_) => e,
-    }
+    Or::new(parser1, thunk_to_parser())
 }
 
 /// Provides a convenient shortcut for the or combinator. allowing the passing


### PR DESCRIPTION
# Introduction
This PR starts playing with associated types for combinators, very similarly to how rust approaches map, fold, filter...etc with iterators.

# Linked Issues
#94 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
