### PR TITLE
Add Map method to MatchStatus type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,6 @@ impl<U, T> MatchStatus<U, T> {
     ///
     /// ```
     /// let input = vec!['a'];
-    /// let v = parcel::MatchStatus::<&[char], char>::Match{span: 0..1, remainder: &input[1..], inner: 'a'};
     /// assert_eq!(
     ///   Some('a'),
     ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.is_match()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,8 +124,8 @@ impl<U, T> MatchStatus<U, T> {
     }
 
     /// This method transforms type `parcel::MatchStatus<U, T>` to type
-    /// `parcel::MatchStatus<U, V>` via a closure, map_fn, allowing
-    /// transformation ofthe result from `T -> V`.
+    /// `Option<T>`. If the type is of the `Match` variant `Option::Some(T)` is
+    /// returned otherwise `Option::None`. is returned.
     ///
     /// # Examples
     ///
@@ -133,13 +133,36 @@ impl<U, T> MatchStatus<U, T> {
     /// let input = vec!['a'];
     /// let v = parcel::MatchStatus::<&[char], char>::Match{span: 0..1, remainder: &input[1..], inner: 'a'};
     /// assert_eq!(
+    ///   Some('a'),
+    ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.is_match()
+    ///  );
+    /// ```
+    pub fn is_match(self) -> Option<T> {
+        match self {
+            MatchStatus::Match {
+                span: _,
+                remainder: _,
+                inner,
+            } => Some(inner),
+            MatchStatus::NoMatch(_) => None,
+        }
+    }
+
+    /// This method transforms type `parcel::MatchStatus<U, T>` to type
+    /// `parcel::MatchStatus<U, V>` via a closure, map_fn, allowing
+    /// transformation ofthe result from `T -> V`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let input = vec!['a'];
+    /// assert_eq!(
     ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: true},
     ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.map(|c| c.is_ascii())
     ///  );
     /// ```
     pub fn map<V, F>(self, map_fn: F) -> MatchStatus<U, V>
     where
-        Self: Sized,
         F: Fn(T) -> V,
     {
         match self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,39 @@ impl<U, T> MatchStatus<U, T> {
             _ => None,
         }
     }
+
+    /// This method transforms type `parcel::MatchStatus<U, T>` to type
+    /// `parcel::MatchStatus<U, V>` via a closure, map_fn, allowing
+    /// transformation ofthe result from `T -> V`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// let input = vec!['a'];
+    /// let v = parcel::MatchStatus::<&[char], char>::Match{span: 0..1, remainder: &input[1..], inner: 'a'};
+    /// assert_eq!(
+    ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: true},
+    ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.map(|c| c.is_ascii())
+    ///  );
+    /// ```
+    pub fn map<V, F>(self, map_fn: F) -> MatchStatus<U, V>
+    where
+        Self: Sized,
+        F: Fn(T) -> V,
+    {
+        match self {
+            MatchStatus::Match {
+                span,
+                remainder,
+                inner,
+            } => MatchStatus::Match {
+                span,
+                remainder,
+                inner: map_fn(inner),
+            },
+            MatchStatus::NoMatch(rem) => MatchStatus::NoMatch(rem),
+        }
+    }
 }
 
 /// Represents the state of parser execution, wrapping the above


### PR DESCRIPTION
# Introduction
This PR adds a `map` method to the `MatchStatus` type to transform a type of `MatchStatus<U, T>` to a type of `MatchStatus<U, V>`. Additionally this adds an `is_match` method for transforming a `MatchStatus<U, T>` to an `Option<T>` type.

```rust
let input = vec!['a'];
assert_eq!(
  Some('a'),
  parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.is_match()
);
```

```rust
let input = vec!['a'];
assert_eq!(
  parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: true},
  parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.map(|c| c.is_ascii())
);
```

# Linked Issues
resolves #98
 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
