### PR TITLE
Update `MatchStatus.is_match()` method to `MatchStatus.some()` to satisfy clippy

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,10 @@ impl<U, T> MatchStatus<U, T> {
     /// let input = vec!['a'];
     /// assert_eq!(
     ///   Some('a'),
-    ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.is_match()
+    ///   parcel::MatchStatus::Match{span: 0..1, remainder: &input[1..], inner: 'a'}.some()
     ///  );
     /// ```
-    pub fn is_match(self) -> Option<T> {
+    pub fn some(self) -> Option<T> {
         match self {
             MatchStatus::Match {
                 span: _,


### PR DESCRIPTION
# Introduction
Clippy prefers `is_*` methods take a reference to self as a convention. This PR updates the method name to `some` similarly to the `ok` method on `Result` to avoid conflicting with the `is_*` convention.
# Linked Issues
resolves #103 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
