### PR TITLE
Remove `impl` statements in favor of where clauses where from all but returns

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,12 +256,13 @@ pub trait Parser<'a, A, B> {
     ///   expect_byte(0x01).or(|| expect_byte(0x00)).parse(&input)
     /// );
     /// ```
-    fn or<P>(self, thunk: impl Fn() -> P + 'a) -> BoxedParser<'a, A, B>
+    fn or<P, F>(self, thunk: F) -> BoxedParser<'a, A, B>
     where
         Self: Sized + 'a,
         A: Copy + 'a,
         B: 'a,
         P: Parser<'a, A, B> + 'a,
+        F: Fn() -> P + 'a,
     {
         BoxedParser::new(or(self, thunk))
     }
@@ -924,11 +925,12 @@ where
 ///   parcel::or(expect_byte(0x01), || expect_byte(0x00)).parse(&input)
 /// );
 /// ```
-pub fn or<'a, P1, P2, A, B>(parser1: P1, thunk_to_parser: impl Fn() -> P2) -> impl Parser<'a, A, B>
+pub fn or<'a, P1, P2, F, A, B>(parser1: P1, thunk_to_parser: F) -> impl Parser<'a, A, B>
 where
     A: Copy + 'a + Borrow<A>,
     P1: Parser<'a, A, B>,
     P2: Parser<'a, A, B>,
+    F: Fn() -> P2,
 {
     Or::new(parser1, thunk_to_parser())
 }


### PR DESCRIPTION
# Introduction
This is a small PR to standardize on only using `impl` keywords on return values to keep the rest of the signature clear. This follows the idea that I will try to prefer to use `where` clauses unless it is more concise (read doesn't cause significant additional unclear type parameters and constraints) in a definition. Example being the following:

```rust
fn or<P, F>(self, thunk: F) -> BoxedParser<'a, A, B>
where
    Self: Sized + 'a,
    A: Copy + 'a,
    B: 'a,
    P: Parser<'a, A, B> + 'a,
    F: Fn() -> P + 'a,
{
    BoxedParser::new(or(self, thunk))
}
```

would be prefered over:

```rust
fn or<P>(self, thunk: impl Fn() -> P + 'a) -> BoxedParser<'a, A, B>
where
    Self: Sized + 'a,
    A: Copy + 'a,
    B: 'a,
    P: Parser<'a, A, B> + 'a,
{
    BoxedParser::new(or(self, thunk))
}
```

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
