### PR TITLE
Experimenting with a macro-based assertion generation DSL

### DIFF
--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-extern crate parcel;
 use parcel::parsers::byte::{any_byte, expect_byte};
 use parcel::Parser;
 

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-extern crate parcel;
 use parcel::parsers::character::{any_character, expect_character};
 use parcel::Parser;
 

--- a/src/tests/binary_parsing.rs
+++ b/src/tests/binary_parsing.rs
@@ -1,108 +1,70 @@
 use crate::parsers::byte::{any_byte, expect_byte};
 use crate::prelude::v1::*;
-use crate::{predicate, take_until_n};
+
+macro_rules! assert_parser {
+    {$parser:expr, should parse $elements:literal elements from $input:expr => $output:expr} => {
+        let input_vec: Vec<(usize, u8)> = $input.iter().copied().enumerate().collect();
+
+        assert_eq!(
+            Ok(MatchStatus::Match {
+                span: 0..$elements,
+                remainder: &input_vec[$elements..],
+                inner: $output
+            }),
+            $parser.parse(&input_vec[..])
+        );
+    };
+    {$parser:expr, should parse $elements:literal element from $input:expr => $output:expr} => {
+        assert_parser!($parser, should parse $elements elements from $input => $output);
+    };
+
+    // No Match
+    {$parser:expr, should not parse $input:expr} => {
+        let input_vec: Vec<(usize, u8)> = $input.iter().copied().enumerate().collect();
+
+        assert_eq!(
+            Ok(MatchStatus::NoMatch(&input_vec[..])),
+            $parser.parse(&input_vec[..])
+        );
+    };
+}
 
 #[test]
 fn parser_should_parse_byte_match() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..1,
-            remainder: &input[1..],
-            inner: 0x00
-        }),
-        expect_byte(0x00).parse(&input)
-    );
+    assert_parser!(expect_byte(0x00), should parse 1 element from [0x00, 0x01, 0x02] => 0x00);
 }
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_byte(0xFF).skip().parse(&input)
-    );
+    assert_parser!(expect_byte(0xFF).skip(), should not parse [0x00, 0x01, 0x02]);
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..4,
-            remainder: &input[4..],
-            inner: vec![0x00, 0x00, 0x00, 0x00]
-        }),
-        take_until_n(expect_byte(0x00), 4).parse(&input)
-    );
+    assert_parser!(expect_byte(0x00).take_until_n(4), should parse 4 elements from [0x00, 0x00, 0x00, 0x00, 0x01, 0x02] => vec![0x00, 0x00, 0x00, 0x00]);
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x00, 0x00, 0x01, 0x02]
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..3,
-            remainder: &input[3..],
-            inner: vec![0x00, 0x00, 0x00]
-        }),
-        expect_byte(0x00).take_until_n(3).parse(&input)
-    );
+    assert_parser!(expect_byte(0x00).take_until_n(3), should parse 3 elements from [0x00, 0x00, 0x00, 0x00, 0x01, 0x02] => vec![0x00, 0x00, 0x00]);
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x00, 0x01, 0x02]
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..2,
-            remainder: &input[2..],
-            inner: vec![0x00, 0x00]
-        }),
-        expect_byte(0x00).take_until_n(3).parse(&input)
-    );
+    assert_parser!(expect_byte(0x00).take_until_n(3), should parse 2 elements from [0x00, 0x00, 0x01, 0x02] => vec![0x00, 0x00]);
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_byte(0x03).take_until_n(2).parse(&input)
-    );
+    assert_parser!(expect_byte(0x03).take_until_n(2), should not parse [0x00, 0x01, 0x02]);
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_byte(0x03).take_n(2).parse(&input)
-    );
+    assert_parser!(expect_byte(0x03).take_n(2), should not parse [0x00, 0x01, 0x02]);
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input: Vec<(usize, u8)> = vec![0x00, 0x01, 0x02].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        predicate(any_byte(), |&c| c != 0x00).parse(&input)
-    );
+    assert_parser!(any_byte().predicate(|&c| c != 0x00), should not parse [0x00, 0x01, 0x02]);
 }

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -2,19 +2,6 @@ use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
 
 macro_rules! assert_parser {
-    {should parse $input:literal using $parser:expr => $output:expr} => {
-        let input_vec: Vec<(usize, char)> = $input.chars().enumerate().collect();
-        let input_len = input_vec.len();
-
-        assert_eq!(
-            Ok(MatchStatus::Match {
-                span: 0..input_len,
-                remainder: &input_vec[input_len..],
-                inner: $output
-            }),
-            $parser.parse(&input_vec[..])
-        );
-    };
     {should parse $elements:literal elements from $input:literal using $parser:expr => $output:expr} => {
         let input_vec: Vec<(usize, char)> = $input.chars().enumerate().collect();
 
@@ -44,7 +31,7 @@ macro_rules! assert_parser {
 
 #[test]
 fn parser_should_parse_char_match() {
-    assert_parser!(should parse "abc" using expect_character('a') => 'a');
+    assert_parser!(should parse 1 element from "abc" using expect_character('a') => 'a');
 }
 
 #[test]

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -3,7 +3,7 @@ use crate::prelude::v1::*;
 
 macro_rules! assert_parser {
     {should parse $input:literal using $parser:expr => $output:expr} => {
-        let input_vec: Vec<(usize, char)> = $input.chars().enumerate.collect();
+        let input_vec: Vec<(usize, char)> = $input.chars().enumerate().collect();
         let input_len = input_vec.len();
 
         assert_eq!(
@@ -44,7 +44,7 @@ macro_rules! assert_parser {
 
 #[test]
 fn parser_should_parse_char_match() {
-    assert_parser!(should parse 1 element from "abc" using expect_character('a') => 'a');
+    assert_parser!(should parse "abc" using expect_character('a') => 'a');
 }
 
 #[test]

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -2,18 +2,40 @@ use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
 use crate::{predicate, take_until_n};
 
+macro_rules! assert_parser {
+    {should parse $input:literal using $parser:expr => $output:expr} => {
+        let input_vec: Vec<(usize, char)> = $input.chars().enumerate.collect();
+        let input_len = input_vec.len();
+
+        assert_eq!(
+            Ok(MatchStatus::Match {
+                span: 0..input_len,
+                remainder: &input_vec[input_len..],
+                inner: $output
+            }),
+            $parser.parse(&input_vec[..])
+        );
+    };
+    {should parse $elements:literal elements from $input:literal using $parser:expr => $output:expr} => {
+        let input_vec: Vec<(usize, char)> = $input.chars().enumerate().collect();
+
+        assert_eq!(
+            Ok(MatchStatus::Match {
+                span: 0..$elements,
+                remainder: &input_vec[$elements..],
+                inner: $output
+            }),
+            $parser.parse(&input_vec[..])
+        );
+    };
+    {should parse $elements:literal element from $input:literal using $parser:expr => $output:expr} => {
+        assert_parser!(should parse $elements elements from $input using $parser => $output);
+    };
+}
+
 #[test]
 fn parser_should_parse_char_match() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..1,
-            remainder: &input[1..],
-            inner: 'a'
-        }),
-        expect_character('a').parse(&input[0..])
-    );
+    assert_parser!(should parse 1 element from "abc" using expect_character('a') => 'a');
 }
 
 #[test]

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -31,6 +31,16 @@ macro_rules! assert_parser {
     {should parse $elements:literal element from $input:literal using $parser:expr => $output:expr} => {
         assert_parser!(should parse $elements elements from $input using $parser => $output);
     };
+
+    // No Match
+    {should not parse $input:literal using $parser:expr} => {
+        let input_vec: Vec<(usize, char)> = $input.chars().enumerate().collect();
+
+        assert_eq!(
+            Ok(MatchStatus::NoMatch(&input_vec[..])),
+            $parser.parse(&input_vec[..])
+        );
+    };
 }
 
 #[test]
@@ -40,12 +50,7 @@ fn parser_should_parse_char_match() {
 
 #[test]
 fn parser_should_not_skip_input_if_parser_does_not_match() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_character('x').skip().parse(&input[0..])
-    );
+    assert_parser!(should not parse "abc" using expect_character('x'));
 }
 
 #[test]

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -1,6 +1,5 @@
 use crate::parsers::character::{any_character, expect_character};
 use crate::prelude::v1::*;
-use crate::{predicate, take_until_n};
 
 macro_rules! assert_parser {
     {should parse $input:literal using $parser:expr => $output:expr} => {
@@ -55,113 +54,45 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 
 #[test]
 fn parser_can_match_with_one_of() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
     let parsers = vec![
         expect_character('b'),
         expect_character('c'),
         expect_character('a'),
     ];
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..1,
-            remainder: &input[1..],
-            inner: 'a'
-        }),
-        crate::one_of(parsers).parse(&input[0..])
-    );
+    assert_parser!(should parse 1 element from "abc" using crate::one_of(parsers) => 'a');
 }
 
 #[test]
 fn parser_can_match_with_take_until_n() {
-    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..4,
-            remainder: &input[4..],
-            inner: vec!['a', 'a', 'a', 'a']
-        }),
-        take_until_n(expect_character('a'), 4).parse(&input[0..])
-    );
+    assert_parser!(should parse 4 elements from "aaaabc" using expect_character('a').take_until_n(4) => vec!['a', 'a', 'a', 'a']);
 }
 
 #[test]
 fn take_until_n_will_match_only_up_to_specified_limit() {
-    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..3,
-            remainder: &input[3..],
-            inner: vec!['a', 'a', 'a']
-        }),
-        expect_character('a').take_until_n(3).parse(&input[0..])
-    );
+    assert_parser!(should parse 3 elements from "aaaabc" using expect_character('a').take_until_n(3) => vec!['a', 'a', 'a' ]);
 }
 
 #[test]
 fn take_until_n_will_return_as_many_matches_as_possible() {
-    let input: Vec<(usize, char)> = vec!['a', 'a', 'b', 'c'].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..2,
-            remainder: &input[2..],
-            inner: vec!['a', 'a']
-        }),
-        expect_character('a').take_until_n(3).parse(&input[0..])
-    );
+    assert_parser!(should parse 2 elements from "aabc" using expect_character('a').take_until_n(3) => vec!['a', 'a']);
 }
 
 #[test]
 fn take_until_n_returns_a_no_match_on_no_match() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_character('d').take_until_n(2).parse(&input[0..])
-    );
+    assert_parser!(should not parse "abc" using expect_character('d').take_until_n(2));
 }
 
 #[test]
 fn take_n_will_match_only_up_to_specified_limit() {
-    let input: Vec<(usize, char)> = vec!['a', 'a', 'a', 'a', 'b', 'c']
-        .into_iter()
-        .enumerate()
-        .collect();
-
-    assert_eq!(
-        Ok(MatchStatus::Match {
-            span: 0..3,
-            remainder: &input[3..],
-            inner: vec!['a', 'a', 'a']
-        }),
-        expect_character('a').take_n(3).parse(&input[0..])
-    );
+    assert_parser!(should parse 3 elements from "aaaabc" using expect_character('a').take_n(3) => vec!['a', 'a', 'a']);
 }
 
 #[test]
 fn take_n_returns_a_no_match_on_no_match() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
-
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        expect_character('d').take_n(2).parse(&input[0..])
-    );
+    assert_parser!(should not parse "abc" using expect_character('d').take_n(2));
 }
 
 #[test]
 fn predicate_should_not_match_if_case_is_true() {
-    let input: Vec<(usize, char)> = vec!['a', 'b', 'c'].into_iter().enumerate().collect();
-    assert_eq!(
-        Ok(MatchStatus::NoMatch(&input[0..])),
-        predicate(any_character(), |&c| c != 'a').parse(&input[0..])
-    );
+    assert_parser!(should not parse "abc" using any_character().predicate(|&c| c != 'a'));
 }


### PR DESCRIPTION
# Introduction
This PR implements an experimental macro-based DSL for the character parsers only. Currently this looks like:

```rust
assert_parser!(should parse 1 element from "abc" using expect_character('a') => 'a');
```

I'm still deciding if this should include the individual tests in each assertion, looking more like a list of assertions and hefting the reporting of errors to an optional `Result<(), String>` response on the assertion, like:

```rust
assertions!(
  should parse 1 element from "abc" using expect_character('a') => 'a',
  should not parse "abc" using expect_character('x'),
);
```

Or if each test should make it's own assertion independently of the macro call, like:

```rust
#[test]
fn parser_should_parse_char_match() {
    assert_parser!(should parse 1 element from "abc" using expect_character('a') => 'a');
}
```

I will hold off on implementing this for any other tests within the library until I've implemented both approaches within the character parsers module and made a decision on what to consistently apply.

# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
