### PR TITLE
Fix spanning on optional parser types

### DIFF
--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -3,3 +3,4 @@ pub use crate::BoxedParser;
 pub use crate::MatchStatus;
 pub use crate::ParseResult;
 pub use crate::Parser;
+pub use crate::Spanning;


### PR DESCRIPTION
# Introduction
This PR fixes an issue where a `NoMatch` on an optional combinator like `Optional` or `ZeroOrMore` returns a span of `0..0` by adding a new trait `Spanning` for properly pulling span data from an input type.

# Linked Issues
resolves #119 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
