### PR TITLE
Bump cargo version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parcel"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Nate Catelli <ncatelli@packetfire.org>"]
 edition = "2018"
 publish = false


### PR DESCRIPTION
# Introduction
Cargo is tagged at `2.0.0` when it should be `2.0.1` this PR corrects that.
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
