### PR TITLE
Add flamegraph benchmarking

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
 # Add backports
 RUN echo 'deb http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
-    && echo 'deb-src http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
+    && echo 'deb-src http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list
 
 # Install perf for 5.15 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,7 +1,13 @@
-# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/rust/.devcontainer/base.Dockerfile
+ARG VARIANT="buster"
+FROM mcr.microsoft.com/vscode/devcontainers/rust:0-${VARIANT}
 
-FROM mcr.microsoft.com/vscode/devcontainers/rust:0-1
+# Add backports
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
+    && echo 'deb-src http://deb.debian.org/debian bullseye-backports main contrib non-free' >> /etc/apt/sources.list \
 
-# [Optional] Uncomment this section to install additional packages.
-# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-#     && apt-get -y install --no-install-recommends <your-package-list-here>
+# Install perf for 5.15 
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+    linux-perf-5.15 \
+    # Link perf to a known location
+    && ln -s /usr/bin/perf_5.15 /usr/bin/perf

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,14 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/rust
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.217.4/containers/rust
 {
 	"name": "Rust",
 	"build": {
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Use the VARIANT arg to pick a Debian OS version: buster, bullseye
+			// Use bullseye when on local on arm64/Apple Silicon.
+			"VARIANT": "bullseye"
+		}
 	},
 	"runArgs": [
 		"--cap-add=SYS_PTRACE",
@@ -27,10 +32,7 @@
 		"tamasfe.even-better-toml",
 		"serayuzgur.crates"
 	],
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "rustc --version",
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"postCreateCommand": "cargo install flamegraph",
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "vscode"
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,23 +1,58 @@
 name: Test
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
+  release:
+    types:
+      - created
 
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Lint source
-      run: cargo clippy
+      - uses: actions/checkout@v1
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
   unit_test:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
     - name: Run tests
-      run: cargo test
+      uses: actions-rs/cargo@v1
+      with:
+        command: test
   benchmark:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Run benchmark tests
-      run: cargo bench
+    - name: Run run benchmarks
+      uses: actions-rs/cargo@v1
+      with:
+        command: bench
+  flamegraph:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        bench: 
+          - "text_parsing"
+          - "binary_parsing"
+    steps:
+      - uses: actions/checkout@master
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Add cargo-flamegraph
+        run: cargo install flamegraph 
+      - name: Generate benchmark flamegraphs
+        run: cargo flamegraph --bench ${{ matrix.bench }}-- --bench
+      - name: Upload rendered graphs
+        uses: actions/upload-artifact@v2
+        with:
+          name: rendered-benchmark-flamegraphs
+          path: *.svg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,27 +34,4 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: bench
-  flamegraph:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        bench: 
-          - "text_parsing"
-          - "binary_parsing"
-    steps:
-      - uses: actions/checkout@master
-      - name: Set kernel profiling sysctls
-        run: echo "2" > /proc/sys/kernel/perf_event_paranoid
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-      - name: Add cargo-flamegraph
-        run: cargo install flamegraph 
-      - name: Generate benchmark flamegraphs
-        run: cargo flamegraph --bench ${{ matrix.bench }} -- --bench
-      - name: Upload rendered graphs
-        uses: actions/upload-artifact@v2
-        with:
-          name: rendered-benchmark-flamegraphs
-          path: "*.svg"
+

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
           - "binary_parsing"
     steps:
       - uses: actions/checkout@master
+      - name: Set kernel profiling sysctls
+        run: echo "2" > /proc/sys/kernel/perf_event_paranoid
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Add cargo-flamegraph
         run: cargo install flamegraph 
       - name: Generate benchmark flamegraphs
-        run: cargo flamegraph --bench ${{ matrix.bench }}-- --bench
+        run: cargo flamegraph --bench ${{ matrix.bench }} -- --bench
       - name: Upload rendered graphs
         uses: actions/upload-artifact@v2
         with:
           name: rendered-benchmark-flamegraphs
-          path: *.svg
+          path: "*.svg"


### PR DESCRIPTION
# Introduction
This PR updates the devcontainer to include `cargo-flamegraph` and `perf`. Additionally, This adds a test stage to generate benchmark artifacts on PRs
# Linked Issues
resolves #122 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
