### PR TITLE
allow static array as an argument for OneOf combinator

### DIFF
--- a/benches/binary_parsing.rs
+++ b/benches/binary_parsing.rs
@@ -65,12 +65,8 @@ fn parse_one_of(c: &mut Criterion) {
 
     group.bench_function("combinator with byte vec", |b| {
         b.iter(|| {
-            let _expr = parcel::one_of(vec![
-                expect_byte(0x02),
-                expect_byte(0x01),
-                expect_byte(0x00),
-            ])
-            .parse(black_box(&seed_vec));
+            let _expr = parcel::one_of([expect_byte(0x02), expect_byte(0x01), expect_byte(0x00)])
+                .parse(black_box(&seed_vec));
         });
     });
     group.finish();

--- a/benches/text_parsing.rs
+++ b/benches/text_parsing.rs
@@ -66,7 +66,7 @@ fn parse_one_of(c: &mut Criterion) {
 
     group.bench_function("combinator with char vec", |b| {
         b.iter(|| {
-            let _expr = parcel::one_of(vec![
+            let _expr = parcel::one_of([
                 expect_character('c'),
                 expect_character('b'),
                 expect_character('a'),

--- a/src/prelude/v1/mod.rs
+++ b/src/prelude/v1/mod.rs
@@ -1,6 +1,7 @@
 pub use crate::formatter::SpanFormatter;
 pub use crate::BoxedParser;
 pub use crate::MatchStatus;
+pub use crate::OneOfParameterizable;
 pub use crate::ParseResult;
 pub use crate::Parser;
 pub use crate::Spanning;

--- a/src/tests/textual_parsing.rs
+++ b/src/tests/textual_parsing.rs
@@ -45,7 +45,7 @@ fn parser_should_not_skip_input_if_parser_does_not_match() {
 
 #[test]
 fn parser_can_match_with_one_of() {
-    let parsers = vec![
+    let parsers = [
         expect_character('b'),
         expect_character('c'),
         expect_character('a'),


### PR DESCRIPTION
# Introduction
This PR adds support for array types as arguments to the `OneOf` combinators in addition to `Vec`s.
# Linked Issues
resolve #130 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
