### PR TITLE
Refactor/133/port actions rs to rust toolchain

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,0 +1,27 @@
+name: Benchmark
+
+on: 
+  push:
+    branches:
+      - main
+  pull_request:
+  release:
+    types:
+      - created
+
+jobs:
+  build_and_test:
+    name: Bench
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          clean: false
+      - uses: dtolnay/rust-toolchain@stable
+      - name: measure benchmarks on branch
+        run: cargo bench 
+      - name: upload benchmark report
+        uses: actions/upload-artifact@v1
+        with:
+          name: Benchmark report
+          path: target/criterion/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
         with:
@@ -21,17 +21,8 @@ jobs:
   unit_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
     - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-  benchmark:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - name: Run run benchmarks
-      uses: actions-rs/cargo@v1
-      with:
-        command: bench
+      run: cargo test
 

--- a/src/formatter/character/mod.rs
+++ b/src/formatter/character/mod.rs
@@ -103,12 +103,12 @@ impl<'a> SpanFormatter<&'a [char], core::ops::Range<Cursor>> for TextFormatter {
         if input.len() < span.end {
             Err(SpanFormatterErr::OutOfBounds(span))
         } else {
-            let start = (&input[0..span.start])
+            let start = input[0..span.start]
                 .iter()
                 .fold(Cursor::default(), |cursor, &c| {
                     increment_cursor_from_input_char(cursor, self.newline_delimiter, c)
                 });
-            let end = (&input[span.start..span.end])
+            let end = input[span.start..span.end]
                 .iter()
                 .fold(start, |cursor, &c| {
                     increment_cursor_from_input_char(cursor, self.newline_delimiter, c)


### PR DESCRIPTION
# Introduction
This PR breaks up the test and bechmark workflows and ports over everything but the clippy lints to dtolnay's rust-toolchain.
# Linked Issues
resolves #133 
# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
