### PR TITLE
criterion dep 0.3 -> 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 publish = false
 
 [dev-dependencies]
-criterion = "0.3"
+criterion = "0.4"
 
 [[bench]]
 name = "text_parsing"


### PR DESCRIPTION
# Introduction
Small PR to bump the criterion dep to the latest `0.4.x` from `0.3.x`
# Linked Issues

# Dependencies

# Test
- [x] Tested Locally
- [x] Documented

# Review
- [x] Ready for review
- [x] Ready to merge

# Deployment
